### PR TITLE
[YOUQ-36] 퀴즈 조회 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,6 +32,7 @@ dependencies {
     implementation("org.springframework.kafka:spring-kafka")
     implementation("org.springframework.boot:spring-boot-starter-actuator")
     implementation("org.springframework.boot:spring-boot-starter-log4j2")
+    implementation("org.springframework.boot:spring-boot-starter-data-mongodb-reactive")
     implementation("org.springframework.boot:spring-boot-starter-security")
     implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("org.jetbrains.kotlin:kotlin-reflect")

--- a/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
@@ -1,0 +1,20 @@
+package com.youquiz.quiz.domain
+
+import org.springframework.data.annotation.CreatedDate
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+import java.time.LocalDateTime
+
+@Document
+class Quiz(
+    @Id
+    var id: String? = null,
+    val question: String,
+    val answer: Int,
+    val solution: String,
+    val writer: User,
+    val chapterId: String,
+    val answerRate: Long,
+    @CreatedDate
+    val createdDate: LocalDateTime
+)

--- a/src/main/kotlin/com/youquiz/quiz/domain/User.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/User.kt
@@ -1,0 +1,6 @@
+package com.youquiz.quiz.domain
+
+class User(
+    val id: Long,
+    val nickname: String,
+)

--- a/src/main/kotlin/com/youquiz/quiz/dto/FindAllMarkedQuizRequest.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/FindAllMarkedQuizRequest.kt
@@ -1,0 +1,5 @@
+package com.youquiz.quiz.dto
+
+data class FindAllMarkedQuizRequest(
+    val quizIds: List<String>
+)

--- a/src/main/kotlin/com/youquiz/quiz/dto/QuizResponse.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/QuizResponse.kt
@@ -1,0 +1,32 @@
+package com.youquiz.quiz.dto
+
+import com.youquiz.quiz.domain.Quiz
+import com.youquiz.quiz.domain.User
+import java.time.LocalDateTime
+
+data class QuizResponse(
+    val id: String,
+    val question: String,
+    val answer: Int,
+    val solution: String,
+    val writer: User,
+    val chapterId: String,
+    val answerRate: Long,
+    val createdDate: LocalDateTime
+) {
+    companion object {
+        operator fun invoke(quiz: Quiz) =
+            with(quiz) {
+                QuizResponse(
+                    id = id!!,
+                    question = question,
+                    answer = answer,
+                    solution = solution,
+                    writer = writer,
+                    chapterId = chapterId,
+                    answerRate = answerRate,
+                    createdDate = createdDate
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/youquiz/quiz/exception/QuizNotFoundException.kt
+++ b/src/main/kotlin/com/youquiz/quiz/exception/QuizNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.youquiz.quiz.exception
+
+import com.youquiz.quiz.global.exception.ServerException
+
+class QuizNotFoundException(
+    override val message: String = "퀴즈를 찾을 수 없습니다."
+) : ServerException(code = 404, message)

--- a/src/main/kotlin/com/youquiz/quiz/global/config/MongoConfiguration.kt
+++ b/src/main/kotlin/com/youquiz/quiz/global/config/MongoConfiguration.kt
@@ -1,0 +1,10 @@
+package com.youquiz.quiz.global.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.mongodb.config.EnableReactiveMongoAuditing
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories
+
+@Configuration
+@EnableReactiveMongoAuditing
+@EnableReactiveMongoRepositories
+class MongoConfiguration

--- a/src/main/kotlin/com/youquiz/quiz/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/youquiz/quiz/global/config/SecurityConfiguration.kt
@@ -1,9 +1,12 @@
 package com.youquiz.quiz.global.config
 
+import com.github.jwt.authentication.JwtAuthenticationFilter
+import com.github.jwt.core.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
+import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
@@ -13,17 +16,14 @@ import org.springframework.security.web.server.context.NoOpServerSecurityContext
 @EnableWebFluxSecurity
 class SecurityConfiguration {
     @Bean
-    fun filterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
+    fun filterChain(http: ServerHttpSecurity, jwtProvider: JwtProvider): SecurityWebFilterChain =
         with(http) {
             csrf { it.disable() }
             formLogin { it.disable() }
             logout { it.disable() }
             httpBasic { it.authenticationEntryPoint(HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)) }
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
-            authorizeExchange {
-                it.anyExchange()
-                    .permitAll()
-            }
+            addFilterAt(JwtAuthenticationFilter(jwtProvider), SecurityWebFiltersOrder.AUTHORIZATION)
             build()
         }
 }

--- a/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
@@ -1,0 +1,29 @@
+package com.youquiz.quiz.handler
+
+import com.youquiz.quiz.dto.FindAllMarkedQuizRequest
+import com.youquiz.quiz.service.QuizService
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.awaitBody
+import org.springframework.web.reactive.function.server.bodyAndAwait
+
+@Component
+class QuizHandler(
+    private val quizService: QuizService
+) {
+    suspend fun findAllByChapterId(request: ServerRequest): ServerResponse =
+        request.pathVariable("id").let {
+            ServerResponse.ok().bodyAndAwait(quizService.findAllByChapterId(it))
+        }
+
+    suspend fun findAllByWriterId(request: ServerRequest): ServerResponse =
+        request.pathVariable("id").let {
+            ServerResponse.ok().bodyAndAwait(quizService.findAllByWriterId(it.toLong()))
+        }
+
+    suspend fun findAllMarkedQuiz(request: ServerRequest): ServerResponse =
+        request.awaitBody<FindAllMarkedQuizRequest>().let {
+            ServerResponse.ok().bodyAndAwait(quizService.findAllMarkedQuiz(it))
+        }
+}

--- a/src/main/kotlin/com/youquiz/quiz/repository/QuizRepository.kt
+++ b/src/main/kotlin/com/youquiz/quiz/repository/QuizRepository.kt
@@ -1,0 +1,15 @@
+package com.youquiz.quiz.repository
+
+import com.youquiz.quiz.domain.Quiz
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface QuizRepository : CoroutineCrudRepository<Quiz, String> {
+    fun findAllByChapterId(chapterId: String): Flow<Quiz>
+
+    fun findAllByWriterId(writerId: Long): Flow<Quiz>
+
+    fun findAllByIdIn(ids: List<String>): Flow<Quiz>
+}

--- a/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
@@ -1,0 +1,21 @@
+package com.youquiz.quiz.router
+
+import com.youquiz.quiz.handler.QuizHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.coRouter
+
+@Configuration
+class QuizRouter {
+    @Bean
+    fun quizRoutes(handler: QuizHandler): RouterFunction<ServerResponse> =
+        coRouter {
+            "/quiz".nest {
+                GET("/chapter/{id}", handler::findAllByChapterId)
+                GET("/writer/{id}", handler::findAllByWriterId)
+                POST("/mark", handler::findAllMarkedQuiz)
+            }
+        }
+}

--- a/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
@@ -1,0 +1,25 @@
+package com.youquiz.quiz.service
+
+import com.youquiz.quiz.dto.FindAllMarkedQuizRequest
+import com.youquiz.quiz.dto.QuizResponse
+import com.youquiz.quiz.repository.QuizRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.springframework.stereotype.Service
+
+@Service
+class QuizService(
+    private val quizRepository: QuizRepository
+) {
+    fun findAllByChapterId(chapterId: String): Flow<QuizResponse> =
+        quizRepository.findAllByChapterId(chapterId)
+            .map { QuizResponse(it) }
+
+    fun findAllByWriterId(writerId: Long): Flow<QuizResponse> =
+        quizRepository.findAllByWriterId(writerId)
+            .map { QuizResponse(it) }
+
+    fun findAllMarkedQuiz(request: FindAllMarkedQuizRequest): Flow<QuizResponse> =
+        quizRepository.findAllByIdIn(request.quizIds)
+            .map { QuizResponse(it) }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+spring:
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/quiz
 jwt:
   secretKey: dasdsaddsaldldasjdjdajkdjkdsakjldasjkldkjldas
   accessTokenExpire: 30

--- a/src/test/kotlin/com/youquiz/quiz/config/SecurityTestConfiguration.kt
+++ b/src/test/kotlin/com/youquiz/quiz/config/SecurityTestConfiguration.kt
@@ -1,0 +1,15 @@
+package com.youquiz.quiz.config
+
+import com.youquiz.quiz.fixture.jwtProvider
+import com.youquiz.quiz.global.config.SecurityConfiguration
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.security.config.web.server.ServerHttpSecurity
+import org.springframework.security.web.server.SecurityWebFilterChain
+
+@TestConfiguration
+class SecurityTestConfiguration {
+    @Bean
+    fun filterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
+        SecurityConfiguration().filterChain(http, jwtProvider)
+}

--- a/src/test/kotlin/com/youquiz/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/controller/QuizControllerTest.kt
@@ -1,0 +1,134 @@
+package com.youquiz.quiz.controller
+
+import com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper
+import com.ninjasquad.springmockk.MockkBean
+import com.youquiz.quiz.config.SecurityTestConfiguration
+import com.youquiz.quiz.dto.FindAllMarkedQuizRequest
+import com.youquiz.quiz.dto.QuizResponse
+import com.youquiz.quiz.fixture.ID
+import com.youquiz.quiz.fixture.OBJECT_ID
+import com.youquiz.quiz.fixture.createQuiz
+import com.youquiz.quiz.handler.QuizHandler
+import com.youquiz.quiz.router.QuizRouter
+import com.youquiz.quiz.service.QuizService
+import com.youquiz.quiz.util.BaseControllerTest
+import com.youquiz.quiz.util.desc
+import com.youquiz.quiz.util.paramDesc
+import io.mockk.coEvery
+import kotlinx.coroutines.flow.asFlow
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [SecurityTestConfiguration::class])
+@WebFluxTest(QuizRouter::class, QuizHandler::class)
+class QuizControllerTest : BaseControllerTest() {
+    @MockkBean
+    private lateinit var quizService: QuizService
+
+    private val findAllMarkedQuizRequest = FindAllMarkedQuizRequest(quizIds = listOf(OBJECT_ID))
+
+    private val quizResponse = QuizResponse(createQuiz())
+
+    private val findAllMarkedQuizRequestFields = listOf(
+        "quizIds" desc "퀴즈 식별자 목록"
+    )
+
+    private val quizResponseFields = listOf(
+        "id" desc "퀴즈 식별자",
+        "question" desc "지문",
+        "answer" desc "정답",
+        "solution" desc "풀이",
+        "writer" desc "작성자",
+        "chapterId" desc "챕터 식별자",
+        "answerRate" desc "정답률",
+        "createdDate" desc "생성 날짜"
+    )
+
+    private val quizResponsesFields = quizResponseFields.map { "[].${it.path}" desc it.description as String } +
+            listOf(
+                "[].writer.id" desc "유저 식별자",
+                "[].writer.nickname" desc "닉네임"
+            )
+
+    init {
+        describe("findAllByChapterId()는") {
+            context("챕터와 각각의 챕터에 속하는 퀴즈들이 존재하는 경우") {
+                coEvery { quizService.findAllByChapterId(any()) } returns List(3) { quizResponse }.asFlow()
+
+                it("상태 코드 200과 quizResponse들을 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/quiz/chapter/{id}", OBJECT_ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(List::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "챕터 내 퀴즈 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("id" paramDesc "챕터 식별자"),
+                                responseFields(quizResponsesFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("findAllByWriterId()는") {
+            context("유저가 작성한 퀴즈가 존재하는 경우") {
+                coEvery { quizService.findAllByWriterId(any()) } returns List(3) { quizResponse }.asFlow()
+
+                it("상태 코드 200과 quizResponse들을 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/quiz/writer/{id}", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(List::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "유저가 작성한 퀴즈 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("id" paramDesc "유저 식별자"),
+                                responseFields(quizResponsesFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("findAllMarkedQuiz()는") {
+            context("유저가 저장한 퀴즈가 존재하는 경우") {
+                coEvery { quizService.findAllMarkedQuiz(any()) } returns List(3) { quizResponse }.asFlow()
+
+                it("상태 코드 200과 quizResponse들을 반환한다.") {
+                    webClient
+                        .post()
+                        .uri("/quiz/mark")
+                        .bodyValue(findAllMarkedQuizRequest)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(List::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "유저가 저장한 퀴즈 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                requestFields(findAllMarkedQuizRequestFields),
+                                responseFields(quizResponsesFields)
+                            )
+                        )
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/youquiz/quiz/fixture/CommonFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/CommonFixture.kt
@@ -1,0 +1,4 @@
+package com.youquiz.quiz.fixture
+
+const val ID = 1L
+const val OBJECT_ID = "test"

--- a/src/test/kotlin/com/youquiz/quiz/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/JwtFixture.kt
@@ -1,0 +1,23 @@
+package com.youquiz.quiz.fixture
+
+import com.github.jwt.authentication.DefaultJwtAuthentication
+import com.github.jwt.config.JwtConfiguration
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+
+val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
+const val ACCESS_TOKEN_EXPIRE = 5L
+const val REFRESH_TOKEN_EXPIRE = 10L
+val AUTHORITIES = listOf(SimpleGrantedAuthority("USER"))
+val jwtProvider = JwtConfiguration().jwtProvider(
+    secretKey = SECRET_KEY, accessTokenExpire = ACCESS_TOKEN_EXPIRE, refreshTokenExpire = REFRESH_TOKEN_EXPIRE
+)
+
+fun createJwtAuthentication(
+    id: Long = ID,
+    authorities: List<GrantedAuthority> = AUTHORITIES
+): DefaultJwtAuthentication =
+    DefaultJwtAuthentication(
+        id = id,
+        authorities = authorities
+    )

--- a/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
@@ -1,0 +1,33 @@
+package com.youquiz.quiz.fixture
+
+import com.youquiz.quiz.domain.Quiz
+import com.youquiz.quiz.domain.User
+import java.time.LocalDateTime
+
+const val QUESTION = "test"
+const val ANSWER = 1
+const val SOLUTION = "test"
+val WRITER = createUser()
+const val CHAPTER_ID = OBJECT_ID
+const val ANSWER_RATE = 80L
+val CREATED_DATE = LocalDateTime.now()!!
+
+fun createQuiz(
+    id: String = OBJECT_ID,
+    question: String = QUESTION,
+    answer: Int = ANSWER,
+    solution: String = SOLUTION,
+    writer: User = WRITER,
+    chapterId: String = CHAPTER_ID,
+    answerRate: Long = ANSWER_RATE,
+    createDate: LocalDateTime = CREATED_DATE
+): Quiz = Quiz(
+    id = id,
+    question = question,
+    answer = answer,
+    solution = solution,
+    writer = writer,
+    chapterId = chapterId,
+    answerRate = answerRate,
+    createdDate = createDate
+)

--- a/src/test/kotlin/com/youquiz/quiz/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/UserFixture.kt
@@ -1,0 +1,13 @@
+package com.youquiz.quiz.fixture
+
+import com.youquiz.quiz.domain.User
+
+const val NICKNAME = "earlgrey02"
+
+fun createUser(
+    id: Long = ID,
+    nickname: String = NICKNAME
+): User = User(
+    id = id,
+    nickname = nickname
+)

--- a/src/test/kotlin/com/youquiz/quiz/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/service/QuizServiceTest.kt
@@ -1,0 +1,70 @@
+package com.youquiz.quiz.service
+
+import com.youquiz.quiz.dto.FindAllMarkedQuizRequest
+import com.youquiz.quiz.dto.QuizResponse
+import com.youquiz.quiz.fixture.CHAPTER_ID
+import com.youquiz.quiz.fixture.ID
+import com.youquiz.quiz.fixture.createQuiz
+import com.youquiz.quiz.repository.QuizRepository
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+
+class QuizServiceTest : BehaviorSpec() {
+    private val quizRepository = mockk<QuizRepository>()
+
+    private val quizService = QuizService(quizRepository)
+
+    init {
+        Given("챕터와 각각의 챕터에 속하는 퀴즈들이 존재하는 경우") {
+            val quizzes = List(3) { createQuiz() }.apply {
+                asFlow().let {
+                    coEvery { quizRepository.findAllByChapterId(any()) } returns it
+                    coEvery { quizRepository.findAllByIdIn(any()) } returns it
+                }
+            }
+
+            When("유저가 챕터를 들어가면") {
+                val quizResponses = quizService.findAllByChapterId(CHAPTER_ID).toList()
+
+                Then("해당 챕터에 속하는 퀴즈들이 주어진다.") {
+                    quizResponses shouldContainExactly quizzes.map { QuizResponse(it) }
+                }
+            }
+        }
+
+        Given("유저가 저장한 퀴즈가 존재하는 경우") {
+            val markedQuizzes = List(3) { createQuiz() }.apply {
+                coEvery { quizRepository.findAllByIdIn(any()) } returns asFlow()
+            }
+
+            When("유저가 본인이 저장한 퀴즈 보관함에 들어가면") {
+                val quizResponses = quizService.findAllMarkedQuiz(
+                    FindAllMarkedQuizRequest(
+                        quizIds = markedQuizzes.map { it.id!! }
+                    )).toList()
+
+                Then("저장한 퀴즈들이 주어진다.") {
+                    quizResponses shouldContainExactly markedQuizzes.map { QuizResponse(it) }
+                }
+            }
+        }
+
+        Given("유저가 작성한 퀴즈가 존재하는 경우") {
+            val writtenQuizzes = List(3) { createQuiz() }.apply {
+                coEvery { quizRepository.findAllByWriterId(any()) } returns asFlow()
+            }
+
+            When("유저가 본인이 작성한 퀴즈 보관함에 들어가면") {
+                val quizResponses = quizService.findAllByWriterId(ID).toList()
+
+                Then("본인이 작성한 퀴즈들이 주어진다.") {
+                    quizResponses shouldContainExactly writtenQuizzes.map { QuizResponse(it) }
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/youquiz/quiz/util/TestUtil.kt
+++ b/src/test/kotlin/com/youquiz/quiz/util/TestUtil.kt
@@ -1,12 +1,10 @@
 package com.youquiz.quiz.util
 
-import io.mockk.every
-import io.mockk.mockk
+import com.youquiz.quiz.fixture.createJwtAuthentication
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.request.ParameterDescriptor
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
-import org.springframework.security.core.Authentication
 import org.springframework.security.core.context.SecurityContextHolder
 
 infix fun String.desc(description: String): FieldDescriptor =
@@ -16,9 +14,7 @@ infix fun String.paramDesc(description: String): ParameterDescriptor =
     parameterWithName(this).description(description)
 
 fun withMockUser() {
-    SecurityContextHolder.getContext().authentication = mockk<Authentication>().also {
-        every { it.isAuthenticated } returns true
-    }
+    SecurityContextHolder.getContext().authentication = createJwtAuthentication()
 }
 
 val errorResponseFields = listOf(


### PR DESCRIPTION
## 작업 내용

* **특정 챕터에 속한 퀴즈 및 유저가 저장한 퀴즈, 작성한 퀴즈 조회 기능 구현**
* **Quiz 엔티티 구현**
* **MongoDB 설정**

## 관련 이슈

* **Close #3**