### PR TITLE
[YOUQ-82] 퀴즈 채점 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -99,7 +99,9 @@ tasks {
                     "**.*Configuration*",
                     "**.*Exception*",
                     "**.*LogUtil*",
-                    "**.*Client*"
+                    "**.*Client*",
+                    "**.*Producer*",
+                    "**.*Consumer*"
                 )
             }
         }

--- a/src/main/kotlin/com/youquiz/quiz/adapter/producer/UserProducer.kt
+++ b/src/main/kotlin/com/youquiz/quiz/adapter/producer/UserProducer.kt
@@ -1,0 +1,17 @@
+package com.youquiz.quiz.adapter.producer
+
+import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.stereotype.Component
+
+@Component
+class UserProducer(
+    private val kafkaTemplate: KafkaTemplate<String, String>
+) {
+    fun correctAnswer(userId: Long) {
+        kafkaTemplate.send("correctAnswer", userId.toString())
+    }
+
+    fun incorrectAnswer(userId: Long) {
+        kafkaTemplate.send("incorrectAnswer", userId.toString())
+    }
+}

--- a/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
@@ -15,6 +15,7 @@ class Quiz(
     val writer: User,
     val chapterId: String,
     val answerRate: Long,
+) {
     @CreatedDate
-    val createdDate: LocalDateTime
-)
+    val createdDate: LocalDateTime = LocalDateTime.now()
+}

--- a/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
@@ -14,7 +14,9 @@ class Quiz(
     val solution: String,
     val writer: User,
     val chapterId: String,
-    val answerRate: Long,
+    var answerRate: Long,
+    var correctCount: Long,
+    var incorrectCount: Long,
 ) {
     @CreatedDate
     val createdDate: LocalDateTime = LocalDateTime.now()

--- a/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
@@ -14,7 +14,7 @@ class Quiz(
     val solution: String,
     val writer: User,
     val chapterId: String,
-    var answerRate: Long,
+    var answerRate: Double,
     var correctCount: Long,
     var incorrectCount: Long,
 ) {

--- a/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
@@ -21,7 +21,17 @@ class Quiz(
     @CreatedDate
     val createdDate: LocalDateTime = LocalDateTime.now()
 
-    fun changeAnswerRate() {
+    fun correctAnswer() {
+        correctCount += 1
+        changeAnswerRate()
+    }
+
+    fun incorrectAnswer() {
+        incorrectCount += 1
+        changeAnswerRate()
+    }
+
+    private fun changeAnswerRate() {
         answerRate = (correctCount.toDouble() / (correctCount + incorrectCount).toDouble()) * 100
     }
 }

--- a/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/Quiz.kt
@@ -20,4 +20,8 @@ class Quiz(
 ) {
     @CreatedDate
     val createdDate: LocalDateTime = LocalDateTime.now()
+
+    fun changeAnswerRate() {
+        answerRate = (correctCount.toDouble() / (correctCount + incorrectCount).toDouble()) * 100
+    }
 }

--- a/src/main/kotlin/com/youquiz/quiz/dto/CheckAnswerRequest.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/CheckAnswerRequest.kt
@@ -1,0 +1,6 @@
+package com.youquiz.quiz.dto
+
+data class CheckAnswerRequest(
+    val quizId: String,
+    val answer: Int
+)

--- a/src/main/kotlin/com/youquiz/quiz/dto/CheckAnswerResponse.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/CheckAnswerResponse.kt
@@ -1,0 +1,5 @@
+package com.youquiz.quiz.dto
+
+data class CheckAnswerResponse(
+    val isAnswer: Boolean
+)

--- a/src/main/kotlin/com/youquiz/quiz/dto/QuizResponse.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/QuizResponse.kt
@@ -12,7 +12,9 @@ data class QuizResponse(
     val writer: User,
     val chapterId: String,
     val answerRate: Long,
-    val createdDate: LocalDateTime
+    val correctCount: Long,
+    val incorrectCount: Long,
+    val createdDate: LocalDateTime,
 ) {
     companion object {
         operator fun invoke(quiz: Quiz) =
@@ -25,6 +27,8 @@ data class QuizResponse(
                     writer = writer,
                     chapterId = chapterId,
                     answerRate = answerRate,
+                    correctCount = correctCount,
+                    incorrectCount = incorrectCount,
                     createdDate = createdDate
                 )
             }

--- a/src/main/kotlin/com/youquiz/quiz/dto/QuizResponse.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/QuizResponse.kt
@@ -11,7 +11,7 @@ data class QuizResponse(
     val solution: String,
     val writer: User,
     val chapterId: String,
-    val answerRate: Long,
+    val answerRate: Double,
     val correctCount: Long,
     val incorrectCount: Long,
     val createdDate: LocalDateTime,

--- a/src/main/kotlin/com/youquiz/quiz/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/youquiz/quiz/global/config/SecurityConfiguration.kt
@@ -23,6 +23,12 @@ class SecurityConfiguration {
             logout { it.disable() }
             httpBasic { it.authenticationEntryPoint(HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)) }
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
+            authorizeExchange {
+                it.pathMatchers("/quiz/check")
+                    .authenticated()
+                    .anyExchange()
+                    .permitAll()
+            }
             addFilterAt(JwtAuthenticationFilter(jwtProvider), SecurityWebFiltersOrder.AUTHORIZATION)
             build()
         }

--- a/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
@@ -1,12 +1,11 @@
 package com.youquiz.quiz.handler
 
+import com.github.jwt.authentication.JwtAuthentication
+import com.youquiz.quiz.dto.CheckAnswerRequest
 import com.youquiz.quiz.dto.FindAllMarkedQuizRequest
 import com.youquiz.quiz.service.QuizService
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.awaitBody
-import org.springframework.web.reactive.function.server.bodyAndAwait
+import org.springframework.web.reactive.function.server.*
 
 @Component
 class QuizHandler(
@@ -25,5 +24,13 @@ class QuizHandler(
     suspend fun findAllMarkedQuiz(request: ServerRequest): ServerResponse =
         request.awaitBody<FindAllMarkedQuizRequest>().let {
             ServerResponse.ok().bodyAndAwait(quizService.findAllMarkedQuiz(it))
+        }
+
+    suspend fun checkAnswer(request: ServerRequest): ServerResponse =
+        with(request) {
+            val userId = (awaitPrincipal() as JwtAuthentication).id
+            val checkAnswerRequest = awaitBody<CheckAnswerRequest>()
+
+            ServerResponse.ok().bodyValueAndAwait(quizService.checkAnswer(userId, checkAnswerRequest))
         }
 }

--- a/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
@@ -16,6 +16,7 @@ class QuizRouter {
                 GET("/chapter/{id}", handler::findAllByChapterId)
                 GET("/writer/{id}", handler::findAllByWriterId)
                 POST("/mark", handler::findAllMarkedQuiz)
+                POST("/check", handler::checkAnswer)
             }
         }
 }

--- a/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
@@ -33,14 +33,13 @@ class QuizService(
         return quiz.let {
             if (request.answer == it.answer) {
                 userProducer.correctAnswer(userId)
-                it.correctCount += 1
+                it.correctAnswer()
                 CheckAnswerResponse(true)
             } else {
                 userProducer.incorrectAnswer(userId)
-                it.incorrectCount += 1
+                it.incorrectAnswer()
                 CheckAnswerResponse(false)
             }.apply {
-                it.changeAnswerRate()
                 quizRepository.save(it)
             }
         }

--- a/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
@@ -1,5 +1,8 @@
 package com.youquiz.quiz.service
 
+import com.youquiz.quiz.adapter.producer.UserProducer
+import com.youquiz.quiz.dto.CheckAnswerRequest
+import com.youquiz.quiz.dto.CheckAnswerResponse
 import com.youquiz.quiz.dto.FindAllMarkedQuizRequest
 import com.youquiz.quiz.dto.QuizResponse
 import com.youquiz.quiz.repository.QuizRepository
@@ -9,7 +12,8 @@ import org.springframework.stereotype.Service
 
 @Service
 class QuizService(
-    private val quizRepository: QuizRepository
+    private val quizRepository: QuizRepository,
+    private val userProducer: UserProducer
 ) {
     fun findAllByChapterId(chapterId: String): Flow<QuizResponse> =
         quizRepository.findAllByChapterId(chapterId)
@@ -22,4 +26,23 @@ class QuizService(
     fun findAllMarkedQuiz(request: FindAllMarkedQuizRequest): Flow<QuizResponse> =
         quizRepository.findAllByIdIn(request.quizIds)
             .map { QuizResponse(it) }
+
+    suspend fun checkAnswer(userId: Long, request: CheckAnswerRequest): CheckAnswerResponse {
+        val quiz = quizRepository.findById(request.quizId)!!
+
+        return quiz.let {
+            if (request.answer == it.answer) {
+                userProducer.correctAnswer(userId)
+                it.correctCount += 1
+                CheckAnswerResponse(true)
+            } else {
+                userProducer.incorrectAnswer(userId)
+                it.incorrectCount += 1
+                CheckAnswerResponse(false)
+            }.apply {
+                it.changeAnswerRate()
+                quizRepository.save(it)
+            }
+        }
+    }
 }

--- a/src/test/kotlin/com/youquiz/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/controller/QuizControllerTest.kt
@@ -45,6 +45,8 @@ class QuizControllerTest : BaseControllerTest() {
         "writer" desc "작성자",
         "chapterId" desc "챕터 식별자",
         "answerRate" desc "정답률",
+        "correctCount" desc "정답 횟수",
+        "incorrectCount" desc "오답 횟수",
         "createdDate" desc "생성 날짜"
     )
 

--- a/src/test/kotlin/com/youquiz/quiz/domain/QuizTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/domain/QuizTest.kt
@@ -1,0 +1,24 @@
+package com.youquiz.quiz.domain
+
+import com.youquiz.quiz.fixture.createQuiz
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.doubles.shouldBeGreaterThan
+
+class QuizTest : BehaviorSpec() {
+    init {
+        Given("퀴즈가 존재하는 경우") {
+            val quiz = createQuiz()
+
+            When("유저가 해당 퀴즈의 정답을 맞췄다면") {
+                val increasedQuiz = createQuiz().apply {
+                    correctCount += 1
+                    changeAnswerRate()
+                }
+
+                Then("해당 퀴즈의 정답률이 상승한다.") {
+                    increasedQuiz.answerRate shouldBeGreaterThan quiz.answerRate
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/youquiz/quiz/domain/QuizTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/domain/QuizTest.kt
@@ -3,20 +3,29 @@ package com.youquiz.quiz.domain
 import com.youquiz.quiz.fixture.createQuiz
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.doubles.shouldBeGreaterThan
+import io.kotest.matchers.doubles.shouldBeLessThan
 
 class QuizTest : BehaviorSpec() {
     init {
         Given("퀴즈가 존재하는 경우") {
-            val quiz = createQuiz()
+            val quiz = createQuiz().apply {
+                incorrectCount = 0
+                correctCount = 0
+            } // Code Coverage
 
             When("유저가 해당 퀴즈의 정답을 맞췄다면") {
-                val increasedQuiz = createQuiz().apply {
-                    correctCount += 1
-                    changeAnswerRate()
-                }
+                val increasedQuiz = createQuiz().apply { correctAnswer() }
 
                 Then("해당 퀴즈의 정답률이 상승한다.") {
                     increasedQuiz.answerRate shouldBeGreaterThan quiz.answerRate
+                }
+            }
+
+            When("유저가 해당 퀴즈의 정답을 틀렸다면") {
+                val decreasedQuiz = createQuiz().apply { incorrectAnswer() }
+
+                Then("해당 퀴즈의 정답률이 감소한다.") {
+                    decreasedQuiz.answerRate shouldBeLessThan quiz.answerRate
                 }
             }
         }

--- a/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
@@ -9,7 +9,8 @@ const val SOLUTION = "test"
 val WRITER = createUser()
 const val CHAPTER_ID = OBJECT_ID
 const val ANSWER_RATE = 80L
-val CREATED_DATE = LocalDateTime.now()!!
+const val CORRECT_COUNT = 10L
+const val INCORRECT_COUNT = 10L
 
 fun createQuiz(
     id: String = OBJECT_ID,
@@ -19,6 +20,8 @@ fun createQuiz(
     writer: User = WRITER,
     chapterId: String = CHAPTER_ID,
     answerRate: Long = ANSWER_RATE,
+    correctCount: Long = CORRECT_COUNT,
+    incorrectCount: Long = INCORRECT_COUNT
 ): Quiz = Quiz(
     id = id,
     question = question,
@@ -27,4 +30,6 @@ fun createQuiz(
     writer = writer,
     chapterId = chapterId,
     answerRate = answerRate,
+    correctCount = correctCount,
+    incorrectCount = incorrectCount
 )

--- a/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
@@ -8,7 +8,7 @@ const val ANSWER = 1
 const val SOLUTION = "test"
 val WRITER = createUser()
 const val CHAPTER_ID = OBJECT_ID
-const val ANSWER_RATE = 80L
+const val ANSWER_RATE = 50.0
 const val CORRECT_COUNT = 10L
 const val INCORRECT_COUNT = 10L
 
@@ -19,7 +19,7 @@ fun createQuiz(
     solution: String = SOLUTION,
     writer: User = WRITER,
     chapterId: String = CHAPTER_ID,
-    answerRate: Long = ANSWER_RATE,
+    answerRate: Double = ANSWER_RATE,
     correctCount: Long = CORRECT_COUNT,
     incorrectCount: Long = INCORRECT_COUNT
 ): Quiz = Quiz(

--- a/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/QuizFixture.kt
@@ -2,7 +2,6 @@ package com.youquiz.quiz.fixture
 
 import com.youquiz.quiz.domain.Quiz
 import com.youquiz.quiz.domain.User
-import java.time.LocalDateTime
 
 const val QUESTION = "test"
 const val ANSWER = 1
@@ -20,7 +19,6 @@ fun createQuiz(
     writer: User = WRITER,
     chapterId: String = CHAPTER_ID,
     answerRate: Long = ANSWER_RATE,
-    createDate: LocalDateTime = CREATED_DATE
 ): Quiz = Quiz(
     id = id,
     question = question,
@@ -29,5 +27,4 @@ fun createQuiz(
     writer = writer,
     chapterId = chapterId,
     answerRate = answerRate,
-    createdDate = createDate
 )


### PR DESCRIPTION
## 작업 내용

* **퀴즈 채점 기능 구현**
* **Kafka 관련 Jacoco 설정**

## 코멘트

* 외부 서비스 통신과 관련된 기능들(REST 및 비동기 메세지 통신)은 코드 커버리지에서 제외.

## 관련 이슈

* **Close #5**