### PR TITLE
[YOUQ-84] 챕터 CRUD API 구현

### DIFF
--- a/src/main/kotlin/com/youquiz/quiz/domain/Chapter.kt
+++ b/src/main/kotlin/com/youquiz/quiz/domain/Chapter.kt
@@ -1,0 +1,12 @@
+package com.youquiz.quiz.domain
+
+import org.springframework.data.annotation.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document
+class Chapter(
+    @Id
+    var id: String? = null,
+    val description: String,
+    val courseId: String,
+)

--- a/src/main/kotlin/com/youquiz/quiz/dto/ChapterResponse.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/ChapterResponse.kt
@@ -1,0 +1,20 @@
+package com.youquiz.quiz.dto
+
+import com.youquiz.quiz.domain.Chapter
+
+data class ChapterResponse(
+    val id: String,
+    val description: String,
+    val courseId: String
+) {
+    companion object {
+        operator fun invoke(chapter: Chapter): ChapterResponse =
+            with(chapter) {
+                ChapterResponse(
+                    id = id!!,
+                    description = description,
+                    courseId = courseId
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/youquiz/quiz/dto/CreateChapterRequest.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/CreateChapterRequest.kt
@@ -1,0 +1,6 @@
+package com.youquiz.quiz.dto
+
+data class CreateChapterRequest(
+    val description: String,
+    val courseId: String
+)

--- a/src/main/kotlin/com/youquiz/quiz/dto/UpdateChapterRequest.kt
+++ b/src/main/kotlin/com/youquiz/quiz/dto/UpdateChapterRequest.kt
@@ -1,0 +1,5 @@
+package com.youquiz.quiz.dto
+
+data class UpdateChapterRequest(
+    val description: String,
+)

--- a/src/main/kotlin/com/youquiz/quiz/exception/ChapterNotFoundException.kt
+++ b/src/main/kotlin/com/youquiz/quiz/exception/ChapterNotFoundException.kt
@@ -1,0 +1,7 @@
+package com.youquiz.quiz.exception
+
+import com.youquiz.quiz.global.exception.ServerException
+
+class ChapterNotFoundException(
+    override val message: String = "챕터를 찾을 수 없습니다."
+) : ServerException(code = 404, message)

--- a/src/main/kotlin/com/youquiz/quiz/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/youquiz/quiz/global/config/SecurityConfiguration.kt
@@ -4,7 +4,9 @@ import com.github.jwt.authentication.JwtAuthenticationFilter
 import com.github.jwt.core.JwtProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpMethod
 import org.springframework.http.HttpStatus
+import org.springframework.security.config.annotation.method.configuration.EnableReactiveMethodSecurity
 import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
@@ -13,6 +15,7 @@ import org.springframework.security.web.server.authentication.HttpStatusServerEn
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository
 
 @Configuration
+@EnableReactiveMethodSecurity
 @EnableWebFluxSecurity
 class SecurityConfiguration {
     @Bean
@@ -24,7 +27,13 @@ class SecurityConfiguration {
             httpBasic { it.authenticationEntryPoint(HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)) }
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             authorizeExchange {
-                it.anyExchange()
+                it.pathMatchers(HttpMethod.POST, "/api/chapter/**")
+                    .hasAuthority("ADMIN")
+                    .pathMatchers(HttpMethod.PUT, "/api/chapter/**")
+                    .hasAuthority("ADMIN")
+                    .pathMatchers(HttpMethod.DELETE, "/api/chapter/**")
+                    .hasAuthority("ADMIN")
+                    .anyExchange()
                     .authenticated()
             }
             addFilterAt(JwtAuthenticationFilter(jwtProvider), SecurityWebFiltersOrder.AUTHORIZATION)

--- a/src/main/kotlin/com/youquiz/quiz/handler/ChapterHandler.kt
+++ b/src/main/kotlin/com/youquiz/quiz/handler/ChapterHandler.kt
@@ -1,0 +1,37 @@
+package com.youquiz.quiz.handler
+
+import com.youquiz.quiz.dto.CreateChapterRequest
+import com.youquiz.quiz.dto.UpdateChapterRequest
+import com.youquiz.quiz.service.ChapterService
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.*
+
+@Component
+class ChapterHandler(
+    private val chapterService: ChapterService
+) {
+    suspend fun findAllByCourseId(request: ServerRequest): ServerResponse =
+        request.pathVariable("id").let {
+            ServerResponse.ok().bodyAndAwait(chapterService.findAllByCourseId(it))
+        }
+
+    suspend fun createChapter(request: ServerRequest): ServerResponse =
+        request.awaitBody<CreateChapterRequest>().let {
+            ServerResponse.ok().bodyValueAndAwait(chapterService.createChapter(it))
+        }
+
+    suspend fun updateChapter(request: ServerRequest): ServerResponse =
+        with(request) {
+            val id = pathVariable("id")
+            val updateChapterRequest = awaitBody<UpdateChapterRequest>()
+
+            ServerResponse.ok().bodyValueAndAwait(chapterService.updateChapter(id, updateChapterRequest))
+        }
+
+    suspend fun deleteChapter(request: ServerRequest): ServerResponse =
+        request.pathVariable("id").let {
+            chapterService.deleteChapter(it)
+
+            ServerResponse.ok().buildAndAwait()
+        }
+}

--- a/src/main/kotlin/com/youquiz/quiz/repository/ChapterRepository.kt
+++ b/src/main/kotlin/com/youquiz/quiz/repository/ChapterRepository.kt
@@ -1,0 +1,9 @@
+package com.youquiz.quiz.repository
+
+import com.youquiz.quiz.domain.Chapter
+import kotlinx.coroutines.flow.Flow
+import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+
+interface ChapterRepository : CoroutineCrudRepository<Chapter, String> {
+    fun findAllByCourseId(courseId: String): Flow<Chapter>
+}

--- a/src/main/kotlin/com/youquiz/quiz/router/ChapterRouter.kt
+++ b/src/main/kotlin/com/youquiz/quiz/router/ChapterRouter.kt
@@ -1,0 +1,22 @@
+package com.youquiz.quiz.router
+
+import com.youquiz.quiz.handler.ChapterHandler
+import org.springframework.context.annotation.Bean
+import org.springframework.stereotype.Component
+import org.springframework.web.reactive.function.server.RouterFunction
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.coRouter
+
+@Component
+class ChapterRouter {
+    @Bean
+    fun chapterRoutes(handler: ChapterHandler): RouterFunction<ServerResponse> =
+        coRouter {
+            "/api/chapter".nest {
+                GET("/course/{id}", handler::findAllByCourseId)
+                POST("", handler::createChapter)
+                PUT("/{id}", handler::updateChapter)
+                DELETE("/{id}", handler::deleteChapter)
+            }
+        }
+}

--- a/src/main/kotlin/com/youquiz/quiz/service/ChapterService.kt
+++ b/src/main/kotlin/com/youquiz/quiz/service/ChapterService.kt
@@ -1,0 +1,51 @@
+package com.youquiz.quiz.service
+
+import com.youquiz.quiz.domain.Chapter
+import com.youquiz.quiz.dto.ChapterResponse
+import com.youquiz.quiz.dto.CreateChapterRequest
+import com.youquiz.quiz.dto.UpdateChapterRequest
+import com.youquiz.quiz.exception.ChapterNotFoundException
+import com.youquiz.quiz.repository.ChapterRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import org.springframework.stereotype.Service
+
+@Service
+class ChapterService(
+    private val chapterRepository: ChapterRepository
+) {
+    fun findAllByCourseId(courseId: String): Flow<ChapterResponse> =
+        chapterRepository.findAllByCourseId(courseId)
+            .map { ChapterResponse(it) }
+
+    suspend fun createChapter(request: CreateChapterRequest): ChapterResponse =
+        with(request) {
+            chapterRepository.save(
+                Chapter(
+                    description = description,
+                    courseId = courseId
+                )
+            ).let {
+                ChapterResponse(it)
+            }
+        }
+
+    suspend fun updateChapter(id: String, request: UpdateChapterRequest): ChapterResponse =
+        with(request) {
+            chapterRepository.findById(id)?.let {
+                chapterRepository.save(
+                    Chapter(
+                        id = id,
+                        description = description,
+                        courseId = it.courseId
+                    )
+                )
+            }?.let {
+                ChapterResponse(it)
+            } ?: throw ChapterNotFoundException()
+        }
+
+    suspend fun deleteChapter(id: String) {
+        chapterRepository.deleteById(id)
+    }
+}

--- a/src/test/kotlin/com/youquiz/quiz/controller/ChapterControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/controller/ChapterControllerTest.kt
@@ -1,0 +1,155 @@
+package com.youquiz.quiz.controller
+
+import com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper
+import com.ninjasquad.springmockk.MockkBean
+import com.youquiz.quiz.config.SecurityTestConfiguration
+import com.youquiz.quiz.dto.ChapterResponse
+import com.youquiz.quiz.fixture.ID
+import com.youquiz.quiz.fixture.createChapterResponse
+import com.youquiz.quiz.fixture.createCreateChapterRequest
+import com.youquiz.quiz.fixture.createUpdateChapterRequest
+import com.youquiz.quiz.handler.ChapterHandler
+import com.youquiz.quiz.router.ChapterRouter
+import com.youquiz.quiz.service.ChapterService
+import com.youquiz.quiz.util.*
+import io.mockk.coEvery
+import io.mockk.just
+import io.mockk.runs
+import kotlinx.coroutines.flow.asFlow
+import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.context.ContextConfiguration
+
+@ContextConfiguration(classes = [SecurityTestConfiguration::class])
+@WebFluxTest(ChapterRouter::class, ChapterHandler::class)
+class ChapterControllerTest : BaseControllerTest() {
+    @MockkBean
+    private lateinit var chapterService: ChapterService
+
+    private val createChapterRequestFields = listOf(
+        "description" desc "설명",
+        "courseId" desc "코스 식별자"
+    )
+
+    private val updateChapterRequestFields = listOf(
+        "description" desc "설명",
+    )
+
+    private val chapterResponseFields = listOf(
+        "id" desc "식별자",
+        "description" desc "설명",
+        "courseId" desc "코스 식별자"
+    )
+
+    private val chapterResponsesFields = chapterResponseFields.map { "[].${it.path}" desc it.description as String }
+
+    init {
+        describe("findAllByCourseId()는") {
+            context("코스와 각각의 코스에 속하는 챕터들이 존재하는 경우") {
+                coEvery { chapterService.findAllByCourseId(any()) } returns List(3) { createChapterResponse() }.asFlow()
+                withMockUser()
+
+                it("상태 코드 200과 chapterResponse들을 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/chapter/course/{id}", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(List::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "코스 내 챕터 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("id" paramDesc "식별자"),
+                                responseFields(chapterResponsesFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("createChapter()는") {
+            context("어드민이 챕터를 작성해서 제출하는 경우") {
+                coEvery { chapterService.createChapter(any()) } returns createChapterResponse()
+                withMockAdmin()
+
+                it("상태 코드 200과 chapterResponse를 반환한다.") {
+                    webClient
+                        .post()
+                        .uri("/chapter")
+                        .bodyValue(createCreateChapterRequest())
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(ChapterResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "챕터 생성 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                requestFields(createChapterRequestFields),
+                                responseFields(chapterResponseFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("updateChapter()는") {
+            context("어드민이 챕터를 수정해서 제출하는 경우") {
+                coEvery { chapterService.updateChapter(any(), any()) } returns createChapterResponse()
+                withMockAdmin()
+
+                it("상태 코드 200과 chapterResponse를 반환한다.") {
+                    webClient
+                        .put()
+                        .uri("/chapter/{id}", ID)
+                        .bodyValue(createUpdateChapterRequest())
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(ChapterResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "챕터 수정 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                requestFields(updateChapterRequestFields),
+                                responseFields(chapterResponseFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("deleteChapter()는") {
+            context("어드민이 챕터를 삭제하는 경우") {
+                coEvery { chapterService.deleteChapter(any()) } just runs
+                withMockAdmin()
+
+                it("상태 코드 200을 반환한다.") {
+                    webClient
+                        .delete()
+                        .uri("/chapter/{id}", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody()
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "챕터 삭제 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("id" paramDesc "식별자"),
+                            )
+                        )
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/youquiz/quiz/fixture/ChapterFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/ChapterFixture.kt
@@ -1,0 +1,47 @@
+package com.youquiz.quiz.fixture
+
+import com.youquiz.quiz.domain.Chapter
+import com.youquiz.quiz.dto.ChapterResponse
+import com.youquiz.quiz.dto.CreateChapterRequest
+import com.youquiz.quiz.dto.UpdateChapterRequest
+
+const val DESCRIPTION = "test"
+const val COURSE_ID = "test"
+
+fun createCreateChapterRequest(
+    description: String = DESCRIPTION,
+    courseId: String = COURSE_ID
+): CreateChapterRequest =
+    CreateChapterRequest(
+        description = description,
+        courseId = courseId
+    )
+
+fun createUpdateChapterRequest(
+    description: String = DESCRIPTION,
+): UpdateChapterRequest =
+    UpdateChapterRequest(
+        description = description,
+    )
+
+fun createChapterResponse(
+    id: String = ID,
+    description: String = DESCRIPTION,
+    courseId: String = COURSE_ID
+): ChapterResponse =
+    ChapterResponse(
+        id = id,
+        description = description,
+        courseId = courseId
+    )
+
+fun createChapter(
+    id: String = ID,
+    description: String = DESCRIPTION,
+    courseId: String = COURSE_ID
+): Chapter =
+    Chapter(
+        id = id,
+        description = description,
+        courseId = courseId
+    )

--- a/src/test/kotlin/com/youquiz/quiz/service/ChapterServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/service/ChapterServiceTest.kt
@@ -1,0 +1,80 @@
+package com.youquiz.quiz.service
+
+import com.youquiz.quiz.dto.ChapterResponse
+import com.youquiz.quiz.fixture.*
+import com.youquiz.quiz.repository.ChapterRepository
+import io.kotest.core.spec.IsolationMode
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.equality.shouldBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldNotBeEqual
+import io.mockk.*
+import kotlinx.coroutines.flow.asFlow
+import kotlinx.coroutines.flow.toList
+
+class ChapterServiceTest : BehaviorSpec() {
+    private val chapterRepository = mockk<ChapterRepository>()
+
+    private val chapterService = ChapterService(chapterRepository)
+
+    override fun isolationMode(): IsolationMode = IsolationMode.InstancePerTest
+
+    init {
+        Given("코스와 각각의 코스에 속하는 챕터들이 존재하는 경우") {
+            val chapter = createChapter().also {
+                coEvery { chapterRepository.findById(any()) } returns it
+                coEvery { chapterRepository.deleteById(any()) } just runs
+            }
+            val chapters = List(3) { chapter }.apply {
+                asFlow().let {
+                    coEvery { chapterRepository.findAllByCourseId(any()) } returns it
+                }
+            }
+            val updateChapterRequest = createUpdateChapterRequest("update").also {
+                coEvery { chapterRepository.save(any()) } returns createChapter(description = it.description)
+            }
+
+            When("유저가 코스에 들어가면") {
+                val chapterResponses = chapterService.findAllByCourseId(COURSE_ID).toList()
+
+                Then("해당 코스에 속하는 챕터들이 주어진다.") {
+                    chapterResponses shouldContainExactly chapters.map { ChapterResponse(it) }
+                }
+            }
+
+            When("어드민이 특정 챕터를 수정하면") {
+                val chapterResponse = chapterService.updateChapter(
+                    id = ID,
+                    request = updateChapterRequest
+                )
+
+                Then("해당 챕터가 수정된다.") {
+                    chapterResponse.description shouldNotBeEqual chapter.description
+                }
+            }
+
+            When("어드민이 특정 챕터를 삭제하면") {
+                chapterService.deleteChapter(ID)
+
+                Then("해당 챕터가 삭제된다.") {
+                    coVerify { chapterRepository.deleteById(any()) }
+                }
+            }
+        }
+
+        Given("어드민이 챕터를 작성 중인 경우") {
+            val chapter = createChapter().also {
+                coEvery { chapterRepository.save(any()) } returns it
+            }
+
+            When("어드민이 챕터를 제출하면") {
+                val chapterResponse = chapterService.createChapter(createCreateChapterRequest())
+
+                Then("챕터가 생성된다.") {
+                    chapterResponse shouldBeEqualToComparingFields ChapterResponse(chapter)
+                }
+            }
+        }
+
+    }
+}

--- a/src/test/kotlin/com/youquiz/quiz/util/TestUtil.kt
+++ b/src/test/kotlin/com/youquiz/quiz/util/TestUtil.kt
@@ -5,6 +5,7 @@ import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.request.ParameterDescriptor
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 
 infix fun String.desc(description: String): FieldDescriptor =
@@ -15,6 +16,11 @@ infix fun String.paramDesc(description: String): ParameterDescriptor =
 
 fun withMockUser() {
     SecurityContextHolder.getContext().authentication = createJwtAuthentication()
+}
+
+fun withMockAdmin() {
+    SecurityContextHolder.getContext().authentication =
+        createJwtAuthentication(authorities = listOf(SimpleGrantedAuthority("ADMIN")))
 }
 
 val errorResponseFields = listOf(


### PR DESCRIPTION
## 작업 내용

* **챕터 생성, 조회, 수정, 삭제 기능 구현**

## 코멘트

* 챕터 생성, 수정, 삭제에 대해서 어드민 권한을 요구하도록 구현
* 어드민 권한 API에 대한 테스트를 위해 withMockAdmin() 구현

## 관련 이슈

* **Close #14**