### PR TITLE
[#22] 퀴즈 단일 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
@@ -12,6 +12,11 @@ import org.springframework.web.reactive.function.server.*
 class QuizHandler(
     private val quizService: QuizService
 ) {
+    suspend fun getQuizById(request: ServerRequest): ServerResponse =
+        request.pathVariable("id").let {
+            ServerResponse.ok().bodyValueAndAwait(quizService.getQuizById(it))
+        }
+
     suspend fun getQuizzesByChapterId(request: ServerRequest): ServerResponse =
         request.pathVariable("id").let {
             ServerResponse.ok().bodyAndAwait(quizService.getQuizzesByChapterId(it))

--- a/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
@@ -28,8 +28,8 @@ class QuizHandler(
         }
 
     suspend fun getQuizzesLikedQuiz(request: ServerRequest): ServerResponse =
-        request.awaitAuthentication().run {
-            ServerResponse.ok().bodyAndAwait(quizService.getQuizzesLikedQuiz(id))
+        request.pathVariable("id").let {
+            ServerResponse.ok().bodyAndAwait(quizService.getQuizzesLikedQuiz(it))
         }
 
     suspend fun createQuiz(request: ServerRequest): ServerResponse =

--- a/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
@@ -17,7 +17,7 @@ class QuizRouter {
                 GET("/chapter/{id}", handler::getQuizzesByChapterId)
                 GET("/writer/{id}", handler::getQuizzesByWriterId)
                 GET("/{id}/like", handler::likeQuiz)
-                GET("/liked", handler::getQuizzesLikedQuiz)
+                GET("/liked-user/{id}", handler::getQuizzesLikedQuiz)
                 POST("", handler::createQuiz)
                 POST("/{id}/check", handler::checkAnswer)
                 PUT("/{id}", handler::updateQuizById)

--- a/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/youquiz/quiz/router/QuizRouter.kt
@@ -13,6 +13,7 @@ class QuizRouter {
     fun quizRoutes(handler: QuizHandler): RouterFunction<ServerResponse> =
         coRouter {
             "/api/quiz".nest {
+                GET("/{id}", handler::getQuizById)
                 GET("/chapter/{id}", handler::getQuizzesByChapterId)
                 GET("/writer/{id}", handler::getQuizzesByWriterId)
                 GET("/{id}/like", handler::likeQuiz)

--- a/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
@@ -27,6 +27,9 @@ class QuizService(
     private val userClient: UserClient,
     private val userProducer: UserProducer
 ) {
+    suspend fun getQuizById(id: String): QuizResponse =
+        quizRepository.findById(id)?.let { QuizResponse(it) } ?: throw QuizNotFoundException()
+
     fun getQuizzesByChapterId(chapterId: String): Flow<QuizResponse> =
         quizRepository.findAllByChapterId(chapterId)
             .map { QuizResponse(it) }

--- a/src/test/kotlin/com/youquiz/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/controller/QuizControllerTest.kt
@@ -67,6 +67,31 @@ class QuizControllerTest : BaseControllerTest() {
     )
 
     init {
+        describe("getQuizById()는") {
+            context("퀴즈가 존재하는 경우") {
+                coEvery { quizService.getQuizById(any()) } returns createQuizResponse()
+
+                it("상태 코드 200과 quizResponse를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/quiz/{id}", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(QuizResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "식별자를 통한 퀴즈 단일 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                pathParameters("id" paramDesc "식별자"),
+                                responseFields(quizResponseFields)
+                            )
+                        )
+                }
+            }
+        }
+
         describe("getQuizzesByChapterId()는") {
             context("챕터와 각각의 챕터에 속하는 퀴즈들이 존재하는 경우") {
                 coEvery { quizService.getQuizzesByChapterId(any()) } returns flowOf(createQuizResponse())
@@ -125,7 +150,7 @@ class QuizControllerTest : BaseControllerTest() {
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
                     webClient
                         .get()
-                        .uri("/quiz/liked")
+                        .uri("/quiz/liked-user/{id}", ID)
                         .exchange()
                         .expectStatus()
                         .isOk

--- a/src/test/kotlin/com/youquiz/quiz/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/service/QuizServiceTest.kt
@@ -50,6 +50,14 @@ class QuizServiceTest : BehaviorSpec() {
                 coEvery { quizRepository.save(any()) } returns createQuiz(question = it.question)
             }
 
+            When("유저가 특정 퀴즈를 조회하면") {
+                val quizResponse = quizService.getQuizById(ID)
+
+                Then("해당 퀴즈가 조회된다.") {
+                    quizResponse shouldBeEqualToComparingFields QuizResponse(quiz)
+                }
+            }
+
             When("유저가 챕터를 들어가면") {
                 val quizResponses = quizService.getQuizzesByChapterId(CHAPTER_ID).toList()
 
@@ -73,6 +81,7 @@ class QuizServiceTest : BehaviorSpec() {
                     coVerify { quizRepository.deleteById(any()) }
                 }
             }
+
         }
 
         Given("유저가 좋아요한 퀴즈가 존재하는 경우") {


### PR DESCRIPTION
## 작업 내용

* **퀴즈 단일 조회 기능 구현**

## 코멘트

* 단일 조회 API의 엔드포인트와 좋아요 API의 엔드포인트와 충돌이 발생하므로 좋아요 API의 엔드포인트를 변경

## 관련 이슈

* **Close #22**