### PR TITLE
[#24] 퀴즈 페이징 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/youquiz/quiz/handler/QuizHandler.kt
@@ -5,6 +5,7 @@ import com.youquiz.quiz.dto.request.CreateQuizRequest
 import com.youquiz.quiz.dto.request.UpdateQuizByIdRequest
 import com.youquiz.quiz.global.config.awaitAuthentication
 import com.youquiz.quiz.service.QuizService
+import org.springframework.data.domain.PageRequest
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.server.*
 
@@ -18,8 +19,19 @@ class QuizHandler(
         }
 
     suspend fun getQuizzesByChapterId(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            ServerResponse.ok().bodyAndAwait(quizService.getQuizzesByChapterId(it))
+        with(request) {
+            val chapterId = pathVariable("id")
+            val page = queryParamOrNull("page")?.toInt()
+            val size = queryParamOrNull("size")?.toInt()
+
+            ServerResponse.ok().bodyAndAwait(
+                if ((page != null) && (size != null)) {
+                    quizService.getQuizzesByChapterId(chapterId, PageRequest.of(page, size))
+                } else {
+                    quizService.getQuizzesByChapterId(chapterId)
+                }
+            )
+
         }
 
     suspend fun getQuizzesByWriterId(request: ServerRequest): ServerResponse =

--- a/src/main/kotlin/com/youquiz/quiz/repository/QuizRepository.kt
+++ b/src/main/kotlin/com/youquiz/quiz/repository/QuizRepository.kt
@@ -2,12 +2,15 @@ package com.youquiz.quiz.repository
 
 import com.youquiz.quiz.domain.Quiz
 import kotlinx.coroutines.flow.Flow
+import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.kotlin.CoroutineCrudRepository
 import org.springframework.stereotype.Repository
 
 @Repository
 interface QuizRepository : CoroutineCrudRepository<Quiz, String> {
     fun findAllByChapterId(chapterId: String): Flow<Quiz>
+
+    fun findAllByChapterId(chapterId: String, pageable: Pageable): Flow<Quiz>
 
     fun findAllByWriterId(writerId: String): Flow<Quiz>
 

--- a/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/youquiz/quiz/service/QuizService.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.async
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
 
 @Service
@@ -32,6 +33,10 @@ class QuizService(
 
     fun getQuizzesByChapterId(chapterId: String): Flow<QuizResponse> =
         quizRepository.findAllByChapterId(chapterId)
+            .map { QuizResponse(it) }
+
+    fun getQuizzesByChapterId(chapterId: String, pageable: Pageable): Flow<QuizResponse> =
+        quizRepository.findAllByChapterId(chapterId, pageable)
             .map { QuizResponse(it) }
 
     fun getQuizzesByWriterId(writerId: String): Flow<QuizResponse> =
@@ -65,7 +70,7 @@ class QuizService(
     ): QuizResponse =
         with(request) {
             quizRepository.findById(id)?.let {
-                if ((authentication.id == it.writerId) or authentication.isAdmin()) {
+                if ((authentication.id == it.writerId) || authentication.isAdmin()) {
                     quizRepository.save(
                         Quiz(
                             id = id,
@@ -87,7 +92,7 @@ class QuizService(
 
     suspend fun deleteQuizById(id: String, authentication: DefaultJwtAuthentication) {
         quizRepository.findById(id)?.let {
-            if ((authentication.id == it.writerId) or authentication.isAdmin()) {
+            if ((authentication.id == it.writerId) || authentication.isAdmin()) {
                 quizRepository.deleteById(id)
             } else throw PermissionDeniedException()
         } ?: throw QuizNotFoundException()
@@ -103,7 +108,7 @@ class QuizService(
             val incorrectQuizIds = findUserByIdResponse.incorrectQuizIds
 
             quiz.apply {
-                if ((id !in correctQuizIds) and (id !in incorrectQuizIds)) {
+                if ((id !in correctQuizIds) && (id !in incorrectQuizIds)) {
                     userProducer.checkAnswer(
                         CheckAnswerEvent(
                             userId = userId,

--- a/src/test/kotlin/com/youquiz/quiz/fixture/CommonFixture.kt
+++ b/src/test/kotlin/com/youquiz/quiz/fixture/CommonFixture.kt
@@ -1,6 +1,8 @@
 package com.youquiz.quiz.fixture
 
+import org.springframework.data.domain.PageRequest
 import java.time.LocalDateTime
 
 const val ID = "test"
 val CREATED_DATE = LocalDateTime.now()!!
+val PAGEABLE = PageRequest.of(0, 3)

--- a/src/test/kotlin/com/youquiz/quiz/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/youquiz/quiz/service/QuizServiceTest.kt
@@ -43,6 +43,7 @@ class QuizServiceTest : BehaviorSpec() {
             val quizzes = listOf(quiz).apply {
                 asFlow().let {
                     coEvery { quizRepository.findAllByChapterId(any()) } returns it
+                    coEvery { quizRepository.findAllByChapterId(any(), any()) } returns it
                     coEvery { quizRepository.findAllByIdIn(any()) } returns it
                 }
             }
@@ -60,9 +61,13 @@ class QuizServiceTest : BehaviorSpec() {
 
             When("유저가 챕터를 들어가면") {
                 val quizResponses = quizService.getQuizzesByChapterId(CHAPTER_ID).toList()
+                val quizResponsesWithPaging = quizService.getQuizzesByChapterId(CHAPTER_ID, PAGEABLE).toList()
 
                 Then("해당 챕터에 속하는 퀴즈들이 주어진다.") {
-                    quizResponses shouldContainExactly quizzes.map { QuizResponse(it) }
+                    quizzes.map { QuizResponse(it) }.let {
+                        quizResponses shouldContainExactly it
+                        quizResponsesWithPaging shouldContainExactly it
+                    }
                 }
             }
 


### PR DESCRIPTION
## 작업 내용

* **챕터별 퀴즈 페이징 조회 기능 구현**

## 코멘트

* 기존의 QuizService의 getQuizzesByChapterId를 오버로딩해서 구현

## 관련 이슈

* **Close #24**