### PR TITLE
[#26] 정답률 필터링 기능이 포함된 챕터별 퀴즈 페이징 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/quizit/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/quizit/quiz/handler/QuizHandler.kt
@@ -18,20 +18,19 @@ class QuizHandler(
             ServerResponse.ok().bodyValueAndAwait(quizService.getQuizById(it))
         }
 
-    suspend fun getQuizzesByChapterId(request: ServerRequest): ServerResponse =
+    suspend fun getQuizzesByChapterIdAndAnswerRateRange(request: ServerRequest): ServerResponse =
         with(request) {
             val chapterId = pathVariable("id")
-            val page = queryParamOrNull("page")?.toInt()
-            val size = queryParamOrNull("size")?.toInt()
+            val page = queryParamOrNull("page")!!.toInt()
+            val size = queryParamOrNull("size")!!.toInt()
+            val answerRateRange = queryParamOrNull("range")!!.split(",").map { it.toDouble() }.toSet()
 
-            ServerResponse.ok().bodyAndAwait(
-                if ((page != null) && (size != null)) {
-                    quizService.getQuizzesByChapterId(chapterId, PageRequest.of(page, size))
-                } else {
-                    quizService.getQuizzesByChapterId(chapterId)
-                }
-            )
-
+            ServerResponse.ok()
+                .bodyAndAwait(
+                    quizService.getQuizzesByChapterIdAndAnswerRateRange(
+                        chapterId, answerRateRange, PageRequest.of(page, size)
+                    )
+                )
         }
 
     suspend fun getQuizzesByWriterId(request: ServerRequest): ServerResponse =

--- a/src/main/kotlin/com/quizit/quiz/repository/QuizRepository.kt
+++ b/src/main/kotlin/com/quizit/quiz/repository/QuizRepository.kt
@@ -8,9 +8,9 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface QuizRepository : CoroutineCrudRepository<Quiz, String> {
-    fun findAllByChapterId(chapterId: String): Flow<Quiz>
-
-    fun findAllByChapterId(chapterId: String, pageable: Pageable): Flow<Quiz>
+    fun findAllByChapterIdAndAnswerRateBetween(
+        chapterId: String, minAnswerRate: Double, maxAnswerRate: Double, pageable: Pageable
+    ): Flow<Quiz>
 
     fun findAllByWriterId(writerId: String): Flow<Quiz>
 

--- a/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
@@ -14,7 +14,11 @@ class QuizRouter {
         coRouter {
             "/api/quiz".nest {
                 GET("/{id}", handler::getQuizById)
-                GET("/chapter/{id}", handler::getQuizzesByChapterId)
+                GET(
+                    "/chapter/{id}",
+                    queryParam("page") { true } and queryParam("size") { true } and queryParam("range") { true },
+                    handler::getQuizzesByChapterIdAndAnswerRateRange
+                )
                 GET("/writer/{id}", handler::getQuizzesByWriterId)
                 GET("/{id}/like", handler::likeQuiz)
                 GET("/liked-user/{id}", handler::getQuizzesLikedQuiz)

--- a/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
@@ -31,13 +31,13 @@ class QuizService(
     suspend fun getQuizById(id: String): QuizResponse =
         quizRepository.findById(id)?.let { QuizResponse(it) } ?: throw QuizNotFoundException()
 
-    fun getQuizzesByChapterId(chapterId: String): Flow<QuizResponse> =
-        quizRepository.findAllByChapterId(chapterId)
-            .map { QuizResponse(it) }
-
-    fun getQuizzesByChapterId(chapterId: String, pageable: Pageable): Flow<QuizResponse> =
-        quizRepository.findAllByChapterId(chapterId, pageable)
-            .map { QuizResponse(it) }
+    fun getQuizzesByChapterIdAndAnswerRateRange(
+        chapterId: String, answerRateRange: Set<Double>, pageable: Pageable
+    ): Flow<QuizResponse> =
+        with(answerRateRange) {
+            quizRepository.findAllByChapterIdAndAnswerRateBetween(chapterId, min(), max(), pageable)
+                .map { QuizResponse(it) }
+        }
 
     fun getQuizzesByWriterId(writerId: String): Flow<QuizResponse> =
         quizRepository.findAllByWriterId(writerId)

--- a/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
@@ -93,16 +93,16 @@ class QuizControllerTest : BaseControllerTest() {
             }
         }
 
-        describe("getQuizzesByChapterId()는") {
+        describe("getQuizzesByChapterIdAndAnswerRateRange()는") {
             context("챕터와 각각의 챕터에 속하는 퀴즈들이 존재하는 경우") {
                 flowOf(createQuizResponse()).let {
-                    coEvery { quizService.getQuizzesByChapterId(any()) } returns it
+                    coEvery { quizService.getQuizzesByChapterIdAndAnswerRateRange(any(), any(), any()) } returns it
                 }
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
                     webClient
                         .get()
-                        .uri("/quiz/chapter/{id}", ID)
+                        .uri("/quiz/chapter/{id}?page={page}&size={size}&range={range}", ID, 0, 1, "0,1")
                         .exchange()
                         .expectStatus()
                         .isOk
@@ -113,36 +113,10 @@ class QuizControllerTest : BaseControllerTest() {
                                 Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                                 Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                                 pathParameters("id" paramDesc "식별자"),
-                                responseFields(quizResponsesFields)
-                            )
-                        )
-                }
-            }
-
-            context("챕터와 각각의 챕터에 속하는 퀴즈들이 페이지 형태로 존재하는 경우") {
-                flowOf(createQuizResponse()).let {
-                    coEvery { quizService.getQuizzesByChapterId(any(), any()) } returns it
-                }
-
-                it("상태 코드 200과 quizResponse들을 페이징으로 반환한다.") {
-                    webClient
-                        .get()
-                        .uri("/quiz/chapter/{id}?page={page}&size={size}", ID, 0, 1)
-                        .exchange()
-                        .expectStatus()
-                        .isOk
-                        .expectBody(List::class.java)
-                        .consumeWith(
-                            WebTestClientRestDocumentationWrapper.document(
-                                "챕터 식별자를 통한 퀴즈 페이징 조회 성공(200)",
-                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
-                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
-                                pathParameters("id" paramDesc "식별자"),
                                 queryParameters(
-                                    listOf(
-                                        ("page" paramDesc "페이지 번호").optional(),
-                                        ("size" paramDesc "페이지 크기").optional()
-                                    )
+                                    "page" paramDesc "페이지 번호",
+                                    "size" paramDesc "페이지 크기",
+                                    "range" paramDesc "정답률 범위"
                                 ),
                                 responseFields(quizResponsesFields)
                             )

--- a/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
@@ -42,8 +42,11 @@ class QuizServiceTest : BehaviorSpec() {
             }
             val quizzes = listOf(quiz).apply {
                 asFlow().let {
-                    coEvery { quizRepository.findAllByChapterId(any()) } returns it
-                    coEvery { quizRepository.findAllByChapterId(any(), any()) } returns it
+                    coEvery {
+                        quizRepository.findAllByChapterIdAndAnswerRateBetween(
+                            any(), any(), any(), any()
+                        )
+                    } returns it
                     coEvery { quizRepository.findAllByIdIn(any()) } returns it
                 }
             }
@@ -60,13 +63,13 @@ class QuizServiceTest : BehaviorSpec() {
             }
 
             When("유저가 챕터를 들어가면") {
-                val quizResponses = quizService.getQuizzesByChapterId(CHAPTER_ID).toList()
-                val quizResponsesWithPaging = quizService.getQuizzesByChapterId(CHAPTER_ID, PAGEABLE).toList()
+                val quizResponses =
+                    quizService.getQuizzesByChapterIdAndAnswerRateRange(CHAPTER_ID, setOf(0.0, 100.0), PAGEABLE)
+                        .toList()
 
                 Then("해당 챕터에 속하는 퀴즈들이 주어진다.") {
                     quizzes.map { QuizResponse(it) }.let {
                         quizResponses shouldContainExactly it
-                        quizResponsesWithPaging shouldContainExactly it
                     }
                 }
             }


### PR DESCRIPTION
## 작업 내용

* **정답률 필터링 기능이 포함된 챕터별 퀴즈 페이징 조회 기능 구현**
* **기존의 챕터별 퀴즈 조회 API 삭제**

## 코멘트

* URL의 쿼리 스트링으로 page, size, range가 주어져야만 라우팅이 되도록 구현

## 관련 이슈

* **Close #26**