### PR TITLE
[#44] 퀴즈 저장 네이밍 변경

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,7 +39,7 @@ dependencies {
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-reactor")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
-    implementation("com.github.earlgrey02:JWT-Module:1.0.2")
+    implementation("com.github.earlgrey02:JWT-Module:2.0.2")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
     implementation("io.github.microutils:kotlin-logging:3.0.5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")

--- a/src/main/kotlin/com/quizit/quiz/adapter/client/UserClient.kt
+++ b/src/main/kotlin/com/quizit/quiz/adapter/client/UserClient.kt
@@ -2,7 +2,9 @@ package com.quizit.quiz.adapter.client
 
 import com.quizit.quiz.dto.response.GetUserByIdResponse
 import com.quizit.quiz.exception.UserNotFoundException
+import com.quizit.quiz.global.config.getCurrentAuthentication
 import org.springframework.beans.factory.annotation.Value
+import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
@@ -17,6 +19,7 @@ class UserClient(
     suspend fun getUserById(userId: String) =
         webClient.get()
             .uri("$url/api/user/user/{id}", userId)
+            .header(HttpHeaders.AUTHORIZATION, "Bearer ${getCurrentAuthentication().token}")
             .retrieve()
             .onStatus(HttpStatus.NOT_FOUND::equals) { throw UserNotFoundException() }
             .awaitBody<GetUserByIdResponse>()

--- a/src/main/kotlin/com/quizit/quiz/adapter/producer/QuizProducer.kt
+++ b/src/main/kotlin/com/quizit/quiz/adapter/producer/QuizProducer.kt
@@ -2,7 +2,7 @@ package com.quizit.quiz.adapter.producer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.quizit.quiz.dto.event.CheckAnswerEvent
-import com.quizit.quiz.dto.event.LikeQuizEvent
+import com.quizit.quiz.dto.event.MarkQuizEvent
 import org.springframework.kafka.core.KafkaTemplate
 import org.springframework.stereotype.Component
 
@@ -15,7 +15,7 @@ class QuizProducer(
         kafkaTemplate.send("check-answer", objectMapper.writeValueAsString(event))
     }
 
-    fun likeQuiz(event: LikeQuizEvent) {
-        kafkaTemplate.send("like-quiz", objectMapper.writeValueAsString(event))
+    fun markQuiz(event: MarkQuizEvent) {
+        kafkaTemplate.send("mark-quiz", objectMapper.writeValueAsString(event))
     }
 }

--- a/src/main/kotlin/com/quizit/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/quizit/quiz/domain/Quiz.kt
@@ -18,7 +18,7 @@ class Quiz(
     var answerRate: Double,
     var correctCount: Long,
     var incorrectCount: Long,
-    val likedUserIds: MutableSet<String>,
+    val markedUserIds: MutableSet<String>,
     @CreatedDate
     var createdDate: LocalDateTime = LocalDateTime.now()
 ) {
@@ -32,12 +32,12 @@ class Quiz(
         changeAnswerRate()
     }
 
-    fun like(userId: String) {
-        likedUserIds.add(userId)
+    fun mark(userId: String) {
+        markedUserIds.add(userId)
     }
 
-    fun unlike(userId: String) {
-        likedUserIds.remove(userId)
+    fun unmark(userId: String) {
+        markedUserIds.remove(userId)
     }
 
     private fun changeAnswerRate() {

--- a/src/main/kotlin/com/quizit/quiz/dto/event/MarkQuizEvent.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/event/MarkQuizEvent.kt
@@ -1,7 +1,7 @@
 package com.quizit.quiz.dto.event
 
-data class LikeQuizEvent(
+data class MarkQuizEvent(
     val userId: String,
     val quizId: String,
-    val isLike: Boolean
+    val isMarked: Boolean
 )

--- a/src/main/kotlin/com/quizit/quiz/dto/response/GetUserByIdResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/GetUserByIdResponse.kt
@@ -11,5 +11,5 @@ data class GetUserByIdResponse(
     val createdDate: LocalDateTime,
     val correctQuizIds: Set<String>,
     val incorrectQuizIds: Set<String>,
-    val likedQuizIds: Set<String>
+    val markedQuidIds: Set<String>
 )

--- a/src/main/kotlin/com/quizit/quiz/dto/response/QuizResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/QuizResponse.kt
@@ -12,7 +12,7 @@ data class QuizResponse(
     val options: List<String>,
     val correctCount: Long,
     val incorrectCount: Long,
-    val likedUserIds: Set<String>,
+    val markedUserIds: Set<String>,
     val createdDate: LocalDateTime,
 ) {
     companion object {
@@ -27,7 +27,7 @@ data class QuizResponse(
                     answerRate = answerRate,
                     correctCount = correctCount,
                     incorrectCount = incorrectCount,
-                    likedUserIds = likedUserIds,
+                    markedUserIds = markedUserIds,
                     createdDate = createdDate
                 )
             }

--- a/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
@@ -43,5 +43,8 @@ class SecurityConfiguration {
 suspend fun ServerRequest.awaitAuthentication(): DefaultJwtAuthentication =
     this.awaitPrincipal() as DefaultJwtAuthentication
 
+suspend fun getCurrentAuthentication(): DefaultJwtAuthentication =
+    ReactiveSecurityContextHolder.getContext().awaitSingle().authentication as DefaultJwtAuthentication
+
 fun DefaultJwtAuthentication.isAdmin(): Boolean =
     this.isAuthenticated and (this.authorities[0] == SimpleGrantedAuthority("ADMIN"))

--- a/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
@@ -3,6 +3,7 @@ package com.quizit.quiz.global.config
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.authentication.JwtAuthenticationFilter
 import com.github.jwt.core.JwtProvider
+import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
@@ -10,6 +11,7 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.ReactiveSecurityContextHolder
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository
@@ -28,10 +30,10 @@ class SecurityConfiguration {
             httpBasic { it.authenticationEntryPoint(HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)) }
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             authorizeExchange {
-                it.pathMatchers("/api/quiz/admin/**")
+                it.pathMatchers("/quiz/admin/**")
                     .hasAuthority("ADMIN")
                     .anyExchange()
-                    .permitAll()
+                    .authenticated()
             }
             addFilterAt(JwtAuthenticationFilter(jwtProvider), SecurityWebFiltersOrder.AUTHORIZATION)
             build()

--- a/src/main/kotlin/com/quizit/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/quizit/quiz/handler/QuizHandler.kt
@@ -43,9 +43,9 @@ class QuizHandler(
             ServerResponse.ok().bodyAndAwait(quizService.getQuizzesByQuestionContains(it))
         }
 
-    suspend fun getQuizzesLikedQuiz(request: ServerRequest): ServerResponse =
+    suspend fun getMarkedQuizzes(request: ServerRequest): ServerResponse =
         request.pathVariable("id").let {
-            ServerResponse.ok().bodyAndAwait(quizService.getQuizzesLikedQuiz(it))
+            ServerResponse.ok().bodyAndAwait(quizService.getMarkedQuizzes(it))
         }
 
     suspend fun createQuiz(request: ServerRequest): ServerResponse =
@@ -84,12 +84,12 @@ class QuizHandler(
             ServerResponse.ok().bodyValueAndAwait(quizService.checkAnswer(id, userId, checkAnswerRequest))
         }
 
-    suspend fun likeQuiz(request: ServerRequest): ServerResponse =
+    suspend fun markQuiz(request: ServerRequest): ServerResponse =
         with(request) {
             val id = pathVariable("id")
             val userId = awaitAuthentication().id
 
-            quizService.likeQuiz(id, userId)
+            quizService.markQuiz(id, userId)
 
             ServerResponse.ok().buildAndAwait()
         }

--- a/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
@@ -21,8 +21,8 @@ class QuizRouter {
                     handler::getQuizzesByChapterIdAndAnswerRateRange
                 )
                 GET("/writer/{id}", handler::getQuizzesByWriterId)
-                GET("/{id}/like", handler::likeQuiz)
-                GET("/liked-user/{id}", handler::getQuizzesLikedQuiz)
+                GET("/{id}/mark", handler::markQuiz)
+                GET("/marked-user/{id}", handler::getMarkedQuizzes)
                 POST("", handler::createQuiz)
                 POST("/{id}/check", handler::checkAnswer)
                 PUT("/{id}", handler::updateQuizById)

--- a/src/test/kotlin/com/quizit/quiz/config/SecurityTestConfiguration.kt
+++ b/src/test/kotlin/com/quizit/quiz/config/SecurityTestConfiguration.kt
@@ -1,34 +1,15 @@
 package com.quizit.quiz.config
 
-import com.github.jwt.authentication.JwtAuthenticationFilter
 import com.quizit.quiz.fixture.jwtProvider
+import com.quizit.quiz.global.config.SecurityConfiguration
 import org.springframework.boot.test.context.TestConfiguration
 import org.springframework.context.annotation.Bean
-import org.springframework.http.HttpStatus
-import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.web.server.SecurityWebFilterChain
-import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
-import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository
 
 @TestConfiguration
 class SecurityTestConfiguration {
     @Bean
     fun filterChain(http: ServerHttpSecurity): SecurityWebFilterChain =
-        with(http) {
-            csrf { it.disable() }
-            formLogin { it.disable() }
-            logout { it.disable() }
-            httpBasic { it.authenticationEntryPoint(HttpStatusServerEntryPoint(HttpStatus.UNAUTHORIZED)) }
-            securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
-            authorizeExchange {
-                it.pathMatchers("/admin/**")
-                    .hasAuthority("ADMIN")
-                    .anyExchange()
-                    .permitAll()
-            }
-            addFilterAt(JwtAuthenticationFilter(jwtProvider), SecurityWebFiltersOrder.AUTHORIZATION)
-            build()
-        }
-
+        SecurityConfiguration().filterChain(http, jwtProvider)
 }

--- a/src/test/kotlin/com/quizit/quiz/controller/ChapterControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/ChapterControllerTest.kt
@@ -50,6 +50,7 @@ class ChapterControllerTest : BaseControllerTest() {
         describe("getChaptersByCourseId()는") {
             context("코스와 각각의 코스에 속하는 챕터들이 존재하는 경우") {
                 coEvery { chapterService.getChaptersByCourseId(any()) } returns flowOf(createChapterResponse())
+                withMockUser()
 
                 it("상태 코드 200과 chapterResponse들을 반환한다.") {
                     webClient

--- a/src/test/kotlin/com/quizit/quiz/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/CourseControllerTest.kt
@@ -53,6 +53,7 @@ class CourseControllerTest : BaseControllerTest() {
         describe("getCoursesByCurriculumId()는") {
             context("커리큘럼과 각각의 커리큘럼에 속하는 코스들이 존재하는 경우") {
                 coEvery { courseService.getCoursesByCurriculumId(any()) } returns flowOf(createCourseResponse())
+                withMockUser()
 
                 it("상태 코드 200과 courseResponse들을 반환한다.") {
                     webClient

--- a/src/test/kotlin/com/quizit/quiz/controller/CurriculumControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/CurriculumControllerTest.kt
@@ -51,6 +51,7 @@ class CurriculumControllerTest : BaseControllerTest() {
         describe("getCurriculums()는") {
             context("커리큘럼들이 존재하는 경우") {
                 coEvery { curriculumService.getCurriculums() } returns flowOf(createCurriculumResponse())
+                withMockUser()
 
                 it("상태 코드 200과 curriculumResponse들을 반환한다.") {
                     webClient

--- a/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
@@ -72,6 +72,7 @@ class QuizControllerTest : BaseControllerTest() {
         describe("getQuizById()는") {
             context("퀴즈가 존재하는 경우") {
                 coEvery { quizService.getQuizById(any()) } returns createQuizResponse()
+                withMockUser()
 
                 it("상태 코드 200과 quizResponse를 반환한다.") {
                     webClient
@@ -95,6 +96,7 @@ class QuizControllerTest : BaseControllerTest() {
 
             context("퀴즈가 존재하지 않는 경우") {
                 coEvery { quizService.getQuizById(any()) } throws QuizNotFoundException()
+                withMockUser()
 
                 it("상태 코드 404를 반환한다.") {
                     webClient
@@ -119,9 +121,10 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("getQuizzesByChapterIdAndAnswerRateRange()는") {
             context("챕터와 각각의 챕터에 속하는 퀴즈들이 존재하는 경우") {
-                flowOf(createQuizResponse()).let {
-                    coEvery { quizService.getQuizzesByChapterIdAndAnswerRateRange(any(), any(), any()) } returns it
-                }
+                coEvery {
+                    quizService.getQuizzesByChapterIdAndAnswerRateRange(any(), any(), any())
+                } returns flowOf(createQuizResponse())
+                withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
                     webClient
@@ -152,6 +155,7 @@ class QuizControllerTest : BaseControllerTest() {
         describe("getQuizzesByWriterId()는") {
             context("유저가 작성한 퀴즈가 존재하는 경우") {
                 coEvery { quizService.getQuizzesByWriterId(any()) } returns flowOf(createQuizResponse())
+                withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
                     webClient
@@ -177,6 +181,7 @@ class QuizControllerTest : BaseControllerTest() {
         describe("getQuizzesByQuestionContains()는") {
             context("주어진 키워드를 문제 지문에 포함하는 퀴즈가 존재하는 경우") {
                 coEvery { quizService.getQuizzesByQuestionContains(any()) } returns flowOf(createQuizResponse())
+                withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
                     webClient

--- a/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
@@ -57,7 +57,7 @@ class QuizControllerTest : BaseControllerTest() {
         "options" desc "선지",
         "correctCount" desc "정답 횟수",
         "incorrectCount" desc "오답 횟수",
-        "likedUserIds" desc "좋아요한 유저 리스트",
+        "markedUserIds" desc "저장한 유저 리스트",
         "createdDate" desc "생성 날짜",
     )
 
@@ -204,22 +204,22 @@ class QuizControllerTest : BaseControllerTest() {
             }
         }
 
-        describe("getQuizzesLikedQuiz()는") {
-            context("유저가 좋아요한 퀴즈가 존재하는 경우") {
-                coEvery { quizService.getQuizzesLikedQuiz(any()) } returns flowOf(createQuizResponse())
+        describe("getMarkedQuizzes()는") {
+            context("유저가 저장한 퀴즈가 존재하는 경우") {
+                coEvery { quizService.getMarkedQuizzes(any()) } returns flowOf(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
                     webClient
                         .get()
-                        .uri("/quiz/liked-user/{id}", ID)
+                        .uri("/quiz/marked-user/{id}", ID)
                         .exchange()
                         .expectStatus()
                         .isOk
                         .expectBody(List::class.java)
                         .consumeWith(
                             WebTestClientRestDocumentationWrapper.document(
-                                "유저가 좋아요한 퀴즈 전체 조회 성공(200)",
+                                "유저가 저장한 퀴즈 전체 조회 성공(200)",
                                 Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                                 Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                                 responseFields(quizResponsesFields)
@@ -458,22 +458,22 @@ class QuizControllerTest : BaseControllerTest() {
             }
         }
 
-        describe("likeQuiz()는") {
+        describe("markQuiz()는") {
             context("주어진 퀴즈 식별자에 대한 퀴즈가 존재하는 경우") {
-                coEvery { quizService.likeQuiz(any(), any()) } just runs
+                coEvery { quizService.markQuiz(any(), any()) } just runs
                 withMockUser()
 
-                it("상태 코드 200과 정답 여부가 담긴 checkAnswerResponse를 반환한다.") {
+                it("상태 코드 200을 반환한다.") {
                     webClient
                         .get()
-                        .uri("/quiz/{id}/like", ID)
+                        .uri("/quiz/{id}/mark", ID)
                         .exchange()
                         .expectStatus()
                         .isOk
                         .expectBody(CheckAnswerResponse::class.java)
                         .consumeWith(
                             WebTestClientRestDocumentationWrapper.document(
-                                "퀴즈 좋아요 성공(200)",
+                                "퀴즈 저장 성공(200)",
                                 Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                                 Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                                 pathParameters("id" paramDesc "식별자"),
@@ -483,20 +483,20 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("주어진 퀴즈 식별자에 대한 퀴즈가 존재하지 않는 경우") {
-                coEvery { quizService.likeQuiz(any(), any()) } throws QuizNotFoundException()
+                coEvery { quizService.markQuiz(any(), any()) } throws QuizNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404과 에러를 반환한다.") {
                     webClient
                         .get()
-                        .uri("/quiz/{id}/like", ID)
+                        .uri("/quiz/{id}/mark", ID)
                         .exchange()
                         .expectStatus()
                         .isNotFound
                         .expectBody(ErrorResponse::class.java)
                         .consumeWith(
                             WebTestClientRestDocumentationWrapper.document(
-                                "퀴즈 좋아요 실패(404)",
+                                "퀴즈 저장 실패(404)",
                                 Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                                 Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                                 pathParameters("id" paramDesc "식별자"),

--- a/src/test/kotlin/com/quizit/quiz/domain/QuizTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/domain/QuizTest.kt
@@ -32,19 +32,19 @@ class QuizTest : BehaviorSpec() {
                 }
             }
 
-            When("유저가 해당 퀴즈에 좋아요를 했다면") {
-                val likedQuiz = createQuiz().apply { like(ID) }
+            When("유저가 해당 퀴즈를 저장했다면") {
+                val markedQuiz = createQuiz().apply { mark(ID) }
 
-                Then("해당 퀴즈에 좋아요한 유저가 추가된다.") {
-                    likedQuiz.likedUserIds.size shouldBeGreaterThan quiz.likedUserIds.size
+                Then("해당 퀴즈에 저장한 유저가 추가된다.") {
+                    markedQuiz.markedUserIds.size shouldBeGreaterThan quiz.markedUserIds.size
                 }
             }
 
-            When("유저가 해당 퀴즈에 좋아요 취소를 했다면") {
-                val unlikedQuiz = createQuiz().apply { unlike(likedUserIds.random()) }
+            When("유저가 해당 퀴즈를 저장 취소를 했다면") {
+                val unmarkedQuiz = createQuiz().apply { unmark(markedUserIds.random()) }
 
-                Then("해당 퀴즈에 좋아요한 유저가 삭제된다.") {
-                    unlikedQuiz.likedUserIds.size shouldBeLessThan quiz.likedUserIds.size
+                Then("해당 퀴즈에 저장한 유저가 삭제된다.") {
+                    unmarkedQuiz.markedUserIds.size shouldBeLessThan quiz.markedUserIds.size
                 }
             }
         }

--- a/src/test/kotlin/com/quizit/quiz/fixture/QuizFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/QuizFixture.kt
@@ -15,7 +15,7 @@ val OPTIONS = (0..4).map { "option_$it" }
 const val ANSWER_RATE = 50.0
 const val CORRECT_COUNT = 10L
 const val INCORRECT_COUNT = 10L
-val LIKED_USER_IDS = mutableSetOf("user_1")
+val MARKED_USER_IDS = mutableSetOf("user_1")
 
 fun createCreateQuizRequest(
     question: String = QUESTION,
@@ -70,7 +70,7 @@ fun createQuizResponse(
     answerRate: Double = ANSWER_RATE,
     correctCount: Long = CORRECT_COUNT,
     incorrectCount: Long = INCORRECT_COUNT,
-    likedUserIds: Set<String> = LIKED_USER_IDS,
+    markedUserIds: Set<String> = MARKED_USER_IDS,
     createdDate: LocalDateTime = CREATED_DATE
 ): QuizResponse =
     QuizResponse(
@@ -82,7 +82,7 @@ fun createQuizResponse(
         answerRate = answerRate,
         correctCount = correctCount,
         incorrectCount = incorrectCount,
-        likedUserIds = likedUserIds,
+        markedUserIds = markedUserIds,
         createdDate = createdDate
     )
 
@@ -97,7 +97,7 @@ fun createQuiz(
     answerRate: Double = ANSWER_RATE,
     correctCount: Long = CORRECT_COUNT,
     incorrectCount: Long = INCORRECT_COUNT,
-    likedUserIds: MutableSet<String> = LIKED_USER_IDS.toMutableSet(),
+    markedUserIds: MutableSet<String> = MARKED_USER_IDS.toMutableSet(),
     createdDate: LocalDateTime = CREATED_DATE
 ): Quiz = Quiz(
     id = id,
@@ -109,7 +109,7 @@ fun createQuiz(
     options = options,
     answerRate = answerRate,
     correctCount = correctCount,
-    likedUserIds = likedUserIds,
+    markedUserIds = markedUserIds,
     incorrectCount = incorrectCount,
     createdDate = createdDate
 )

--- a/src/test/kotlin/com/quizit/quiz/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/UserFixture.kt
@@ -9,7 +9,7 @@ const val ROLE = "USER"
 const val ALLOW_PUSH = true
 val CORRECT_QUIZ_IDS = setOf("quiz")
 val INCORRECT_QUIZ_IDS = setOf("quiz")
-val LIKED_QUIZ_IDS = setOf("quiz")
+val MARKED_QUIZ_IDS = setOf("quiz")
 
 fun createGetUserByIdResponse(
     id: String = ID,
@@ -20,7 +20,7 @@ fun createGetUserByIdResponse(
     createdDate: LocalDateTime = LocalDateTime.now(),
     correctQuizIds: Set<String> = CORRECT_QUIZ_IDS,
     incorrectQuizIds: Set<String> = INCORRECT_QUIZ_IDS,
-    likedQuizIds: Set<String> = LIKED_QUIZ_IDS
+    markedQuizIds: Set<String> = MARKED_QUIZ_IDS
 ): GetUserByIdResponse =
     GetUserByIdResponse(
         id = id,
@@ -31,5 +31,5 @@ fun createGetUserByIdResponse(
         createdDate = createdDate,
         correctQuizIds = correctQuizIds,
         incorrectQuizIds = incorrectQuizIds,
-        likedQuizIds = likedQuizIds
+        markedQuidIds = markedQuizIds
     )

--- a/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
@@ -23,7 +23,7 @@ class QuizServiceTest : BehaviorSpec() {
 
     private val quizProducer = mockk<QuizProducer>().apply {
         coEvery { checkAnswer(any()) } just runs
-        coEvery { likeQuiz(any()) } just runs
+        coEvery { markQuiz(any()) } just runs
     }
 
     private val quizService = QuizService(
@@ -100,7 +100,7 @@ class QuizServiceTest : BehaviorSpec() {
             }
         }
 
-        Given("유저가 좋아요한 퀴즈가 존재하는 경우") {
+        Given("유저가 저장한 퀴즈가 존재하는 경우") {
             val quizzes = listOf(createQuiz()).apply {
                 asFlow().let {
                     coEvery { quizRepository.findAllByIdIn(any()) } returns it
@@ -109,10 +109,10 @@ class QuizServiceTest : BehaviorSpec() {
 
             coEvery { userClient.getUserById(any()) } returns createGetUserByIdResponse()
 
-            When("유저가 본인이 좋아요한 퀴즈 보관함에 들어가면") {
-                val quizResponses = quizService.getQuizzesLikedQuiz(ID).toList()
+            When("유저가 본인이 저장한 퀴즈 보관함에 들어가면") {
+                val quizResponses = quizService.getMarkedQuizzes(ID).toList()
 
-                Then("유저가 좋아요한 퀴즈들이 주어진다.") {
+                Then("유저가 저장한 퀴즈들이 주어진다.") {
                     quizResponses shouldContainExactly quizzes.map { QuizResponse(it) }
                 }
             }
@@ -198,25 +198,25 @@ class QuizServiceTest : BehaviorSpec() {
             }
         }
 
-        Given("유저가 퀴즈에 좋아요를 하는 경우") {
+        Given("유저가 퀴즈를 저장하는 경우") {
             val quiz = createQuiz().also {
                 coEvery { quizRepository.save(any()) } returns it
                 coEvery { quizRepository.findById(any()) } returns it
             }
 
-            When("유저가 해당 퀴즈에 처음으로 좋아요를 한다면") {
-                quizService.likeQuiz(ID, ID)
+            When("유저가 해당 퀴즈를 처음 저장한다면") {
+                quizService.markQuiz(ID, ID)
 
-                Then("퀴즈에 좋아요가 된다.") {
-                    quiz.likedUserIds.size shouldBeGreaterThan createQuiz().likedUserIds.size
+                Then("퀴즈가 저장된다.") {
+                    quiz.markedUserIds.size shouldBeGreaterThan createQuiz().markedUserIds.size
                 }
             }
 
-            When("이미 유저가 해당 퀴즈에 좋아요를 한 상태라면") {
-                quizService.likeQuiz(ID, quiz.likedUserIds.random())
+            When("이미 유저가 해당 퀴즈를 저장한 상태라면") {
+                quizService.markQuiz(ID, quiz.markedUserIds.random())
 
-                Then("퀴즈에 좋아요가 취소된다.") {
-                    quiz.likedUserIds.size shouldBeLessThan createQuiz().likedUserIds.size
+                Then("퀴즈가 저장 취소된다.") {
+                    quiz.markedUserIds.size shouldBeLessThan createQuiz().markedUserIds.size
                 }
             }
         }


### PR DESCRIPTION
## 작업 내용

* **퀴즈 저장을 'like' 키워드가 아닌 'mark'로 표현하도록 수정**

## 코멘트
* **유저 서비스와 함께 수행되는 PR**

## 관련 이슈

* **Close #44**