### PR TITLE
[#60] Coroutine을 Reactive Streams로 마이그레이션

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,6 +42,7 @@ dependencies {
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml")
     implementation("com.github.earlgrey02:JWT-Module:2.0.2")
     implementation("io.projectreactor.kotlin:reactor-kotlin-extensions")
+    implementation("io.projectreactor.kafka:reactor-kafka")
     implementation("io.github.microutils:kotlin-logging:3.0.5")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.restdocs:spring-restdocs-webtestclient")

--- a/src/main/kotlin/com/quizit/quiz/adapter/client/UserClient.kt
+++ b/src/main/kotlin/com/quizit/quiz/adapter/client/UserClient.kt
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus
 import org.springframework.security.core.context.ReactiveSecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
 import reactor.core.publisher.Mono
 
 @Component
@@ -27,6 +28,6 @@ class UserClient(
                     )
                     .retrieve()
                     .onStatus(HttpStatus.NOT_FOUND::equals) { Mono.error(UserNotFoundException()) }
-                    .bodyToMono(UserResponse::class.java)
+                    .bodyToMono<UserResponse>()
             }
 }

--- a/src/main/kotlin/com/quizit/quiz/adapter/client/UserClient.kt
+++ b/src/main/kotlin/com/quizit/quiz/adapter/client/UserClient.kt
@@ -1,14 +1,15 @@
 package com.quizit.quiz.adapter.client
 
+import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.quizit.quiz.dto.response.UserResponse
 import com.quizit.quiz.exception.UserNotFoundException
-import com.quizit.quiz.global.config.getCurrentAuthentication
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
+import org.springframework.security.core.context.ReactiveSecurityContextHolder
 import org.springframework.stereotype.Component
 import org.springframework.web.reactive.function.client.WebClient
-import org.springframework.web.reactive.function.client.awaitBody
+import reactor.core.publisher.Mono
 
 @Component
 class UserClient(
@@ -16,11 +17,16 @@ class UserClient(
     @Value("\${url.service.user}")
     private val url: String
 ) {
-    suspend fun getUserById(userId: String) =
-        webClient.get()
-            .uri("$url/api/user/user/{id}", userId)
-            .header(HttpHeaders.AUTHORIZATION, "Bearer ${getCurrentAuthentication().token}")
-            .retrieve()
-            .onStatus(HttpStatus.NOT_FOUND::equals) { throw UserNotFoundException() }
-            .awaitBody<UserResponse>()
+    fun getUserById(userId: String): Mono<UserResponse> =
+        ReactiveSecurityContextHolder.getContext()
+            .flatMap {
+                webClient.get()
+                    .uri("$url/api/user/user/{id}", userId)
+                    .header(
+                        HttpHeaders.AUTHORIZATION, "Bearer ${(it.authentication as DefaultJwtAuthentication).token}"
+                    )
+                    .retrieve()
+                    .onStatus(HttpStatus.NOT_FOUND::equals) { Mono.error(UserNotFoundException()) }
+                    .bodyToMono(UserResponse::class.java)
+            }
 }

--- a/src/main/kotlin/com/quizit/quiz/adapter/producer/QuizProducer.kt
+++ b/src/main/kotlin/com/quizit/quiz/adapter/producer/QuizProducer.kt
@@ -3,19 +3,20 @@ package com.quizit.quiz.adapter.producer
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.quizit.quiz.dto.event.CheckAnswerEvent
 import com.quizit.quiz.dto.event.MarkQuizEvent
-import org.springframework.kafka.core.KafkaTemplate
+import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate
 import org.springframework.stereotype.Component
+import reactor.core.publisher.Mono
 
 @Component
 class QuizProducer(
-    private val kafkaTemplate: KafkaTemplate<String, String>,
+    private val kafkaTemplate: ReactiveKafkaProducerTemplate<String, Any>,
     private val objectMapper: ObjectMapper
 ) {
-    fun checkAnswer(event: CheckAnswerEvent) {
+    fun checkAnswer(event: CheckAnswerEvent): Mono<Void> =
         kafkaTemplate.send("check-answer", objectMapper.writeValueAsString(event))
-    }
+            .then()
 
-    fun markQuiz(event: MarkQuizEvent) {
+    fun markQuiz(event: MarkQuizEvent): Mono<Void> =
         kafkaTemplate.send("mark-quiz", objectMapper.writeValueAsString(event))
-    }
+            .then()
 }

--- a/src/main/kotlin/com/quizit/quiz/domain/Chapter.kt
+++ b/src/main/kotlin/com/quizit/quiz/domain/Chapter.kt
@@ -7,7 +7,14 @@ import org.springframework.data.mongodb.core.mapping.Document
 class Chapter(
     @Id
     var id: String? = null,
-    val description: String,
-    val document: String,
-    val courseId: String,
-)
+    var description: String,
+    var document: String,
+    var courseId: String,
+) {
+    fun update(description: String, document: String, courseId: String): Chapter =
+        also {
+            it.description = description
+            it.document = document
+            it.courseId = courseId
+        }
+}

--- a/src/main/kotlin/com/quizit/quiz/domain/Course.kt
+++ b/src/main/kotlin/com/quizit/quiz/domain/Course.kt
@@ -7,7 +7,14 @@ import org.springframework.data.mongodb.core.mapping.Document
 class Course(
     @Id
     var id: String? = null,
-    val title: String,
-    val image: String,
-    val curriculumId: String
-)
+    var title: String,
+    var image: String,
+    var curriculumId: String
+) {
+    fun update(title: String, image: String, curriculumId: String): Course =
+        also {
+            this.title = title
+            this.image = image
+            this.curriculumId = curriculumId
+        }
+}

--- a/src/main/kotlin/com/quizit/quiz/domain/Curriculum.kt
+++ b/src/main/kotlin/com/quizit/quiz/domain/Curriculum.kt
@@ -7,6 +7,12 @@ import org.springframework.data.mongodb.core.mapping.Document
 class Curriculum(
     @Id
     var id: String? = null,
-    val title: String,
-    val image: String
-)
+    var title: String,
+    var image: String
+) {
+    fun update(title: String, image: String): Curriculum =
+        also {
+            it.title = title
+            it.image = image
+        }
+}

--- a/src/main/kotlin/com/quizit/quiz/domain/Quiz.kt
+++ b/src/main/kotlin/com/quizit/quiz/domain/Quiz.kt
@@ -9,18 +9,18 @@ import java.time.LocalDateTime
 class Quiz(
     @Id
     var id: String? = null,
-    val question: String,
-    val answer: Int,
-    val solution: String,
-    val writerId: String,
-    val chapterId: String,
-    val options: List<String>,
+    var question: String,
+    var answer: Int,
+    var solution: String,
+    var writerId: String,
+    var chapterId: String,
+    var options: List<String>,
     var answerRate: Double,
     var correctCount: Long,
     var incorrectCount: Long,
-    val markedUserIds: MutableSet<String>,
-    val likedUserIds: MutableSet<String>,
-    val unlikedUserIds: MutableSet<String>,
+    val markedUserIds: HashSet<String>,
+    val likedUserIds: HashSet<String>,
+    val unlikedUserIds: HashSet<String>,
     @CreatedDate
     var createdDate: LocalDateTime = LocalDateTime.now()
 ) {
@@ -53,4 +53,13 @@ class Quiz(
     private fun changeAnswerRate() {
         answerRate = (correctCount.toDouble() / (correctCount + incorrectCount).toDouble()) * 100
     }
+
+    fun update(question: String, answer: Int, solution: String, chapterId: String, options: List<String>): Quiz =
+        also {
+            it.question = question
+            it.answer = answer
+            it.solution = solution
+            it.chapterId = chapterId
+            it.options = options
+        }
 }

--- a/src/main/kotlin/com/quizit/quiz/domain/enum/Role.kt
+++ b/src/main/kotlin/com/quizit/quiz/domain/enum/Role.kt
@@ -1,0 +1,6 @@
+package com.quizit.quiz.domain.enum
+
+enum class Role {
+    ADMIN,
+    USER
+}

--- a/src/main/kotlin/com/quizit/quiz/dto/response/QuizResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/QuizResponse.kt
@@ -12,9 +12,9 @@ data class QuizResponse(
     val options: List<String>,
     val correctCount: Long,
     val incorrectCount: Long,
-    val markedUserIds: Set<String>,
-    val likedUserIds: Set<String>,
-    val unlikedUserIds: Set<String>,
+    val markedUserIds: HashSet<String>,
+    val likedUserIds: HashSet<String>,
+    val unlikedUserIds: HashSet<String>,
     val createdDate: LocalDateTime,
 ) {
     companion object {

--- a/src/main/kotlin/com/quizit/quiz/dto/response/UserResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/UserResponse.kt
@@ -1,5 +1,6 @@
 package com.quizit.quiz.dto.response
 
+import com.quizit.quiz.domain.enum.Role
 import java.time.LocalDateTime
 
 data class UserResponse(
@@ -8,12 +9,12 @@ data class UserResponse(
     val nickname: String,
     val image: String,
     val level: Int,
-    val role: String,
+    val role: Role,
     val allowPush: Boolean,
     val dailyTarget: Int,
     val answerRate: Double,
     val createdDate: LocalDateTime,
-    val correctQuizIds: Set<String>,
-    val incorrectQuizIds: Set<String>,
-    val markedQuizIds: Set<String>
+    val correctQuizIds: HashSet<String>,
+    val incorrectQuizIds: HashSet<String>,
+    val markedQuizIds: HashSet<String>
 )

--- a/src/main/kotlin/com/quizit/quiz/global/config/KafkaConfiguration.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/config/KafkaConfiguration.kt
@@ -1,0 +1,21 @@
+package com.quizit.quiz.global.config
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.springframework.boot.autoconfigure.kafka.KafkaProperties
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.kafka.core.reactive.ReactiveKafkaProducerTemplate
+import org.springframework.kafka.support.serializer.JsonSerializer
+import reactor.kafka.sender.SenderOptions
+
+@Configuration
+class KafkaConfiguration {
+    @Bean
+    fun reactiveKafkaProducerTemplate(
+        properties: KafkaProperties, objectMapper: ObjectMapper
+    ): ReactiveKafkaProducerTemplate<String, Any> =
+        ReactiveKafkaProducerTemplate(
+            SenderOptions.create<String, Any>(properties.buildProducerProperties())
+                .withValueSerializer(JsonSerializer(objectMapper))
+        )
+}

--- a/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
@@ -3,6 +3,7 @@ package com.quizit.quiz.global.config
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.authentication.JwtAuthenticationFilter
 import com.github.jwt.core.JwtProvider
+import com.quizit.quiz.domain.enum.Role
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
@@ -29,7 +30,7 @@ class SecurityConfiguration {
             securityContextRepository(NoOpServerSecurityContextRepository.getInstance())
             authorizeExchange {
                 it.pathMatchers("/quiz/admin/**")
-                    .hasAuthority("ADMIN")
+                    .hasAuthority(Role.ADMIN.name)
                     .pathMatchers("/actuator/health/**")
                     .permitAll()
                     .anyExchange()
@@ -44,4 +45,4 @@ fun ServerRequest.authentication(): Mono<DefaultJwtAuthentication> =
     principal().cast(DefaultJwtAuthentication::class.java)
 
 fun DefaultJwtAuthentication.isAdmin(): Boolean =
-    isAuthenticated && (authorities[0] == SimpleGrantedAuthority("ADMIN"))
+    isAuthenticated && (authorities[0] == SimpleGrantedAuthority(Role.ADMIN.name))

--- a/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/config/SecurityConfiguration.kt
@@ -3,7 +3,6 @@ package com.quizit.quiz.global.config
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.authentication.JwtAuthenticationFilter
 import com.github.jwt.core.JwtProvider
-import kotlinx.coroutines.reactor.awaitSingle
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatus
@@ -11,12 +10,11 @@ import org.springframework.security.config.annotation.web.reactive.EnableWebFlux
 import org.springframework.security.config.web.server.SecurityWebFiltersOrder
 import org.springframework.security.config.web.server.ServerHttpSecurity
 import org.springframework.security.core.authority.SimpleGrantedAuthority
-import org.springframework.security.core.context.ReactiveSecurityContextHolder
 import org.springframework.security.web.server.SecurityWebFilterChain
 import org.springframework.security.web.server.authentication.HttpStatusServerEntryPoint
 import org.springframework.security.web.server.context.NoOpServerSecurityContextRepository
 import org.springframework.web.reactive.function.server.ServerRequest
-import org.springframework.web.reactive.function.server.awaitPrincipal
+import reactor.core.publisher.Mono
 
 @Configuration
 @EnableWebFluxSecurity
@@ -42,11 +40,8 @@ class SecurityConfiguration {
         }
 }
 
-suspend fun ServerRequest.awaitAuthentication(): DefaultJwtAuthentication =
-    this.awaitPrincipal() as DefaultJwtAuthentication
-
-suspend fun getCurrentAuthentication(): DefaultJwtAuthentication =
-    ReactiveSecurityContextHolder.getContext().awaitSingle().authentication as DefaultJwtAuthentication
+fun ServerRequest.authentication(): Mono<DefaultJwtAuthentication> =
+    principal().cast(DefaultJwtAuthentication::class.java)
 
 fun DefaultJwtAuthentication.isAdmin(): Boolean =
-    this.isAuthenticated and (this.authorities[0] == SimpleGrantedAuthority("ADMIN"))
+    isAuthenticated && (authorities[0] == SimpleGrantedAuthority("ADMIN"))

--- a/src/main/kotlin/com/quizit/quiz/global/exception/GlobalExceptionHandler.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/exception/GlobalExceptionHandler.kt
@@ -3,8 +3,6 @@ package com.quizit.quiz.global.exception
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.quizit.quiz.global.dto.ErrorResponse
 import com.quizit.quiz.global.util.logger
-import kotlinx.coroutines.reactor.awaitSingleOrNull
-import kotlinx.coroutines.reactor.mono
 import org.springframework.boot.web.reactive.error.ErrorWebExceptionHandler
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpStatusCode
@@ -12,27 +10,28 @@ import org.springframework.http.MediaType
 import org.springframework.web.server.ServerWebExchange
 import reactor.core.publisher.Mono
 import reactor.kotlin.core.publisher.toMono
-import java.io.PrintWriter
-import java.io.StringWriter
 
 @Configuration
 class GlobalExceptionHandler(
     private val objectMapper: ObjectMapper
 ) : ErrorWebExceptionHandler {
-    override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> = mono {
-        logger.error { "${ex.message} at ${ex.stackTrace[0]}" }
-
-        val errorResponse = if (ex is ServerException) {
-            ErrorResponse(code = ex.code, message = ex.message)
-        } else {
-            ErrorResponse(code = 500, message = "Internal Server Error")
-        }
-
+    override fun handle(exchange: ServerWebExchange, ex: Throwable): Mono<Void> =
         with(exchange.response) {
+            val errorResponse = if (ex is ServerException) {
+                ErrorResponse(code = ex.code, message = ex.message)
+            } else {
+                ErrorResponse(code = 500, message = "Internal Server Error")
+            }
+
+            logger.error { "${ex.message} at ${ex.stackTrace[0]}" }
+
             statusCode = HttpStatusCode.valueOf(errorResponse.code)
             headers.contentType = MediaType.APPLICATION_JSON
 
-            writeWith(bufferFactory().wrap(objectMapper.writeValueAsBytes(errorResponse)).toMono()).awaitSingleOrNull()
+            writeWith(
+                bufferFactory()
+                    .wrap(objectMapper.writeValueAsBytes(errorResponse))
+                    .toMono()
+            )
         }
-    }
 }

--- a/src/main/kotlin/com/quizit/quiz/global/util/KotlinUtil.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/util/KotlinUtil.kt
@@ -1,0 +1,7 @@
+package com.quizit.quiz.global.util
+
+import reactor.util.function.Tuple2
+
+operator fun <T1, T2> Tuple2<T1, T2>.component1(): T1 = t1
+
+operator fun <T1, T2> Tuple2<T1, T2>.component2(): T2 = t2

--- a/src/main/kotlin/com/quizit/quiz/global/util/WebUtil.kt
+++ b/src/main/kotlin/com/quizit/quiz/global/util/WebUtil.kt
@@ -1,11 +1,11 @@
 package com.quizit.quiz.global.util
 
-import org.springframework.web.reactive.function.server.CoRouterFunctionDsl
 import org.springframework.web.reactive.function.server.RequestPredicate
+import org.springframework.web.reactive.function.server.RouterFunctionDsl
 import org.springframework.web.reactive.function.server.ServerRequest
 import org.springframework.web.reactive.function.server.queryParamOrNull
 
-fun CoRouterFunctionDsl.queryParams(vararg name: String): RequestPredicate =
+fun RouterFunctionDsl.queryParams(vararg name: String): RequestPredicate =
     name.map { queryParam(it) { true } }.reduce { total, next -> total and next }
 
 inline fun <reified T> ServerRequest.queryParamNotNull(name: String): T =

--- a/src/main/kotlin/com/quizit/quiz/handler/ChapterHandler.kt
+++ b/src/main/kotlin/com/quizit/quiz/handler/ChapterHandler.kt
@@ -4,39 +4,41 @@ import com.quizit.quiz.dto.request.CreateChapterRequest
 import com.quizit.quiz.dto.request.UpdateChapterByIdRequest
 import com.quizit.quiz.service.ChapterService
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.*
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.body
+import org.springframework.web.reactive.function.server.bodyToMono
+import reactor.core.publisher.Mono
 
 @Component
 class ChapterHandler(
     private val chapterService: ChapterService
 ) {
-    suspend fun getChapterById(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            ServerResponse.ok().bodyValueAndAwait(chapterService.getChapterById(it))
-        }
+    fun getChapterById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(chapterService.getChapterById(request.pathVariable("id")))
 
-    suspend fun getChaptersByCourseId(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            ServerResponse.ok().bodyAndAwait(chapterService.getChaptersByCourseId(it))
-        }
+    fun getChaptersByCourseId(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(chapterService.getChaptersByCourseId(request.pathVariable("id")))
 
-    suspend fun createChapter(request: ServerRequest): ServerResponse =
-        request.awaitBody<CreateChapterRequest>().let {
-            ServerResponse.ok().bodyValueAndAwait(chapterService.createChapter(it))
-        }
+    fun createChapter(request: ServerRequest): Mono<ServerResponse> =
+        request.bodyToMono<CreateChapterRequest>()
+            .flatMap {
+                ServerResponse.ok()
+                    .body(chapterService.createChapter(it))
+            }
 
-    suspend fun updateChapterById(request: ServerRequest): ServerResponse =
+    fun updateChapterById(request: ServerRequest): Mono<ServerResponse> =
         with(request) {
-            val id = pathVariable("id")
-            val updateChapterByIdRequest = awaitBody<UpdateChapterByIdRequest>()
-
-            ServerResponse.ok().bodyValueAndAwait(chapterService.updateChapterById(id, updateChapterByIdRequest))
+            bodyToMono<UpdateChapterByIdRequest>()
+                .flatMap {
+                    ServerResponse.ok()
+                        .body(chapterService.updateChapterById(pathVariable("id"), it))
+                }
         }
 
-    suspend fun deleteChapterById(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            chapterService.deleteChapterById(it)
-
-            ServerResponse.ok().buildAndAwait()
-        }
+    fun deleteChapterById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(chapterService.deleteChapterById(request.pathVariable("id")))
 }

--- a/src/main/kotlin/com/quizit/quiz/handler/CourseHandler.kt
+++ b/src/main/kotlin/com/quizit/quiz/handler/CourseHandler.kt
@@ -4,39 +4,41 @@ import com.quizit.quiz.dto.request.CreateCourseRequest
 import com.quizit.quiz.dto.request.UpdateCourseByIdRequest
 import com.quizit.quiz.service.CourseService
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.*
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.body
+import org.springframework.web.reactive.function.server.bodyToMono
+import reactor.core.publisher.Mono
 
 @Component
 class CourseHandler(
     private val courseService: CourseService
 ) {
-    suspend fun getCourseById(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            ServerResponse.ok().bodyValueAndAwait(courseService.getCourseById(it))
-        }
+    fun getCourseById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(courseService.getCourseById(request.pathVariable("id")))
 
-    suspend fun getCoursesByCurriculumId(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            ServerResponse.ok().bodyAndAwait(courseService.getCoursesByCurriculumId(it))
-        }
+    fun getCoursesByCurriculumId(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(courseService.getCoursesByCurriculumId(request.pathVariable("id")))
 
-    suspend fun createCourse(request: ServerRequest): ServerResponse =
-        request.awaitBody<CreateCourseRequest>().let {
-            ServerResponse.ok().bodyValueAndAwait(courseService.createCourse(it))
-        }
+    fun createCourse(request: ServerRequest): Mono<ServerResponse> =
+        request.bodyToMono<CreateCourseRequest>()
+            .flatMap {
+                ServerResponse.ok()
+                    .body(courseService.createCourse(it))
+            }
 
-    suspend fun updateCourseById(request: ServerRequest): ServerResponse =
+    fun updateCourseById(request: ServerRequest): Mono<ServerResponse> =
         with(request) {
-            val id = pathVariable("id")
-            val updateCourseByIdRequest = awaitBody<UpdateCourseByIdRequest>()
-
-            ServerResponse.ok().bodyValueAndAwait(courseService.updateCourseById(id, updateCourseByIdRequest))
+            bodyToMono<UpdateCourseByIdRequest>()
+                .flatMap {
+                    ServerResponse.ok()
+                        .body(courseService.updateCourseById(pathVariable("id"), it))
+                }
         }
 
-    suspend fun deleteCourseById(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            courseService.deleteCourseById(it)
-
-            ServerResponse.ok().buildAndAwait()
-        }
+    fun deleteCourseById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(courseService.deleteCourseById(request.pathVariable("id")))
 }

--- a/src/main/kotlin/com/quizit/quiz/handler/CurriculumHandler.kt
+++ b/src/main/kotlin/com/quizit/quiz/handler/CurriculumHandler.kt
@@ -4,38 +4,41 @@ import com.quizit.quiz.dto.request.CreateCurriculumRequest
 import com.quizit.quiz.dto.request.UpdateCurriculumByIdRequest
 import com.quizit.quiz.service.CurriculumService
 import org.springframework.stereotype.Component
-import org.springframework.web.reactive.function.server.*
+import org.springframework.web.reactive.function.server.ServerRequest
+import org.springframework.web.reactive.function.server.ServerResponse
+import org.springframework.web.reactive.function.server.body
+import org.springframework.web.reactive.function.server.bodyToMono
+import reactor.core.publisher.Mono
 
 @Component
 class CurriculumHandler(
     private val curriculumService: CurriculumService
 ) {
-    suspend fun getCurriculumById(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            ServerResponse.ok().bodyValueAndAwait(curriculumService.getCurriculumById(it))
-        }
+    fun getCurriculumById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(curriculumService.getCurriculumById(request.pathVariable("id")))
 
-    suspend fun getCurriculums(request: ServerRequest): ServerResponse =
-        ServerResponse.ok().bodyAndAwait(curriculumService.getCurriculums())
+    fun getCurriculums(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(curriculumService.getCurriculums())
 
-    suspend fun createCurriculum(request: ServerRequest): ServerResponse =
-        request.awaitBody<CreateCurriculumRequest>().let {
-            ServerResponse.ok().bodyValueAndAwait(curriculumService.createCurriculum(it))
-        }
+    fun createCurriculum(request: ServerRequest): Mono<ServerResponse> =
+        request.bodyToMono<CreateCurriculumRequest>()
+            .flatMap {
+                ServerResponse.ok()
+                    .body(curriculumService.createCurriculum(it))
+            }
 
-    suspend fun updateCurriculumById(request: ServerRequest): ServerResponse =
+    fun updateCurriculumById(request: ServerRequest): Mono<ServerResponse> =
         with(request) {
-            val id = pathVariable("id")
-            val updateCurriculumByIdRequest = awaitBody<UpdateCurriculumByIdRequest>()
-
-            ServerResponse.ok()
-                .bodyValueAndAwait(curriculumService.updateCurriculumById(id, updateCurriculumByIdRequest))
+            bodyToMono<UpdateCurriculumByIdRequest>()
+                .flatMap {
+                    ServerResponse.ok()
+                        .body(curriculumService.updateCurriculumById(pathVariable("id"), it))
+                }
         }
 
-    suspend fun deleteCurriculumById(request: ServerRequest): ServerResponse =
-        request.pathVariable("id").let {
-            curriculumService.deleteCurriculumById(it)
-
-            ServerResponse.ok().buildAndAwait()
-        }
+    fun deleteCurriculumById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(curriculumService.deleteCurriculumById(request.pathVariable("id")))
 }

--- a/src/main/kotlin/com/quizit/quiz/repository/ChapterRepository.kt
+++ b/src/main/kotlin/com/quizit/quiz/repository/ChapterRepository.kt
@@ -1,9 +1,9 @@
 package com.quizit.quiz.repository
 
 import com.quizit.quiz.domain.Chapter
-import kotlinx.coroutines.flow.Flow
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
+import reactor.core.publisher.Flux
 
-interface ChapterRepository : CoroutineCrudRepository<Chapter, String> {
-    fun findAllByCourseId(courseId: String): Flow<Chapter>
+interface ChapterRepository : ReactiveMongoRepository<Chapter, String> {
+    fun findAllByCourseId(courseId: String): Flux<Chapter>
 }

--- a/src/main/kotlin/com/quizit/quiz/repository/CourseRepository.kt
+++ b/src/main/kotlin/com/quizit/quiz/repository/CourseRepository.kt
@@ -1,11 +1,11 @@
 package com.quizit.quiz.repository
 
 import com.quizit.quiz.domain.Course
-import kotlinx.coroutines.flow.Flow
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
 
 @Repository
-interface CourseRepository : CoroutineCrudRepository<Course, String> {
-    fun findAllByCurriculumId(curriculumId: String): Flow<Course>
+interface CourseRepository : ReactiveMongoRepository<Course, String> {
+    fun findAllByCurriculumId(curriculumId: String): Flux<Course>
 }

--- a/src/main/kotlin/com/quizit/quiz/repository/CurriculumRepository.kt
+++ b/src/main/kotlin/com/quizit/quiz/repository/CurriculumRepository.kt
@@ -1,8 +1,8 @@
 package com.quizit.quiz.repository
 
 import com.quizit.quiz.domain.Curriculum
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface CurriculumRepository : CoroutineCrudRepository<Curriculum, String>
+interface CurriculumRepository : ReactiveMongoRepository<Curriculum, String>

--- a/src/main/kotlin/com/quizit/quiz/repository/QuizCacheRepository.kt
+++ b/src/main/kotlin/com/quizit/quiz/repository/QuizCacheRepository.kt
@@ -2,10 +2,9 @@ package com.quizit.quiz.repository
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.quizit.quiz.domain.Quiz
-import kotlinx.coroutines.reactor.awaitSingle
-import kotlinx.coroutines.reactor.awaitSingleOrNull
 import org.springframework.data.redis.core.ReactiveRedisTemplate
 import org.springframework.stereotype.Repository
+import reactor.core.publisher.Mono
 import java.time.Duration
 
 @Repository
@@ -14,21 +13,19 @@ class QuizCacheRepository(
     private val redisTemplate: ReactiveRedisTemplate<String, String>,
     private val objectMapper: ObjectMapper
 ) {
-    suspend fun findById(id: String): Quiz? =
+    fun findById(id: String): Mono<Quiz> =
         redisTemplate.opsForValue()
             .get(getKey(id))
-            .awaitSingleOrNull()
-            ?.let { objectMapper.readValue(it, Quiz::class.java) } ?: quizRepository.findById(id)
+            .map { objectMapper.readValue(it, Quiz::class.java) }
+            .switchIfEmpty(Mono.defer { quizRepository.findById(id) })
 
-    suspend fun save(quiz: Quiz): Boolean =
+    fun save(quiz: Quiz): Mono<Boolean> =
         redisTemplate.opsForValue()
             .set(getKey(quiz.id!!), objectMapper.writeValueAsString(quiz), Duration.ofMinutes(60))
-            .awaitSingle()
 
-    suspend fun deleteById(id: String): Boolean =
+    fun deleteById(id: String): Mono<Boolean> =
         redisTemplate.opsForValue()
             .delete(getKey(id))
-            .awaitSingle()
 
     private fun getKey(id: String): String = "quiz:$id"
 }

--- a/src/main/kotlin/com/quizit/quiz/repository/QuizRepository.kt
+++ b/src/main/kotlin/com/quizit/quiz/repository/QuizRepository.kt
@@ -1,20 +1,20 @@
 package com.quizit.quiz.repository
 
 import com.quizit.quiz.domain.Quiz
-import kotlinx.coroutines.flow.Flow
 import org.springframework.data.domain.Pageable
-import org.springframework.data.repository.kotlin.CoroutineCrudRepository
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository
 import org.springframework.stereotype.Repository
+import reactor.core.publisher.Flux
 
 @Repository
-interface QuizRepository : CoroutineCrudRepository<Quiz, String> {
+interface QuizRepository : ReactiveMongoRepository<Quiz, String> {
     fun findAllByChapterIdAndAnswerRateBetween(
         chapterId: String, minAnswerRate: Double, maxAnswerRate: Double, pageable: Pageable
-    ): Flow<Quiz>
+    ): Flux<Quiz>
 
-    fun findAllByWriterId(writerId: String): Flow<Quiz>
+    fun findAllByWriterId(writerId: String): Flux<Quiz>
 
-    fun findAllByIdIn(ids: List<String>): Flow<Quiz>
+    fun findAllByIdIn(ids: List<String>): Flux<Quiz>
 
-    fun findAllByQuestionContains(keyword: String): Flow<Quiz>
+    fun findAllByQuestionContains(keyword: String): Flux<Quiz>
 }

--- a/src/main/kotlin/com/quizit/quiz/router/ChapterRouter.kt
+++ b/src/main/kotlin/com/quizit/quiz/router/ChapterRouter.kt
@@ -5,13 +5,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.reactive.function.server.router
 
 @Configuration
 class ChapterRouter {
     @Bean
     fun chapterRoutes(handler: ChapterHandler): RouterFunction<ServerResponse> =
-        coRouter {
+        router {
             "/chapter".nest {
                 GET("/{id}", handler::getChapterById)
                 GET("/course/{id}", handler::getChaptersByCourseId)

--- a/src/main/kotlin/com/quizit/quiz/router/CourseRouter.kt
+++ b/src/main/kotlin/com/quizit/quiz/router/CourseRouter.kt
@@ -3,13 +3,13 @@ package com.quizit.quiz.router
 import com.quizit.quiz.handler.CourseHandler
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
-import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.reactive.function.server.router
 
 @Configuration
 class CourseRouter {
     @Bean
     fun courseRoutes(handler: CourseHandler) =
-        coRouter {
+        router {
             "/course".nest {
                 GET("/{id}", handler::getCourseById)
                 GET("/curriculum/{id}", handler::getCoursesByCurriculumId)

--- a/src/main/kotlin/com/quizit/quiz/router/CurriculumRouter.kt
+++ b/src/main/kotlin/com/quizit/quiz/router/CurriculumRouter.kt
@@ -5,13 +5,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.reactive.function.server.router
 
 @Configuration
 class CurriculumRouter {
     @Bean
     fun curriculumRoutes(handler: CurriculumHandler): RouterFunction<ServerResponse> =
-        coRouter {
+        router {
             "/curriculum".nest {
                 GET("", handler::getCurriculums)
                 GET("/{id}", handler::getCurriculumById)

--- a/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
@@ -6,13 +6,13 @@ import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.web.reactive.function.server.RouterFunction
 import org.springframework.web.reactive.function.server.ServerResponse
-import org.springframework.web.reactive.function.server.coRouter
+import org.springframework.web.reactive.function.server.router
 
 @Configuration
 class QuizRouter {
     @Bean
     fun quizRoutes(handler: QuizHandler): RouterFunction<ServerResponse> =
-        coRouter {
+        router {
             "/quiz".nest {
                 GET("/search", queryParams("question"), handler::getQuizzesByQuestionContains)
                 GET("/{id}", handler::getQuizById)
@@ -23,11 +23,7 @@ class QuizRouter {
                 )
                 GET("/writer/{id}", handler::getQuizzesByWriterId)
                 GET("/{id}/mark", handler::markQuiz)
-                GET(
-                    "/{id}/evaluate",
-                    queryParams("isLike"),
-                    handler::evaluateQuiz
-                )
+                GET("/{id}/evaluate", queryParams("isLike"), handler::evaluateQuiz)
                 GET("/marked-user/{id}", handler::getMarkedQuizzes)
                 POST("", handler::createQuiz)
                 POST("/{id}/check", handler::checkAnswer)

--- a/src/main/kotlin/com/quizit/quiz/service/CourseService.kt
+++ b/src/main/kotlin/com/quizit/quiz/service/CourseService.kt
@@ -6,22 +6,24 @@ import com.quizit.quiz.dto.request.UpdateCourseByIdRequest
 import com.quizit.quiz.dto.response.CourseResponse
 import com.quizit.quiz.exception.CourseNotFoundException
 import com.quizit.quiz.repository.CourseRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Service
 class CourseService(
     private val courseRepository: CourseRepository
 ) {
-    suspend fun getCourseById(id: String): CourseResponse =
-        courseRepository.findById(id)?.let { CourseResponse(it) } ?: throw CourseNotFoundException()
-    
-    fun getCoursesByCurriculumId(chapterId: String): Flow<CourseResponse> =
+    fun getCourseById(id: String): Mono<CourseResponse> =
+        courseRepository.findById(id)
+            .switchIfEmpty(Mono.error(CourseNotFoundException()))
+            .map { CourseResponse(it) }
+
+    fun getCoursesByCurriculumId(chapterId: String): Flux<CourseResponse> =
         courseRepository.findAllByCurriculumId(chapterId)
             .map { CourseResponse(it) }
 
-    suspend fun createCourse(request: CreateCourseRequest): CourseResponse =
+    fun createCourse(request: CreateCourseRequest): Mono<CourseResponse> =
         with(request) {
             courseRepository.save(
                 Course(
@@ -29,24 +31,18 @@ class CourseService(
                     image = image,
                     curriculumId = curriculumId
                 )
-            ).let { CourseResponse(it) }
+            ).map { CourseResponse(it) }
         }
 
-    suspend fun updateCourseById(id: String, request: UpdateCourseByIdRequest): CourseResponse =
-        with(request) {
-            courseRepository.findById(id) ?: throw CourseNotFoundException()
-            courseRepository.save(
-                Course(
-                    id = id,
-                    title = title,
-                    image = image,
-                    curriculumId = curriculumId
-                )
-            ).let { CourseResponse(it) }
-        }
+    fun updateCourseById(id: String, request: UpdateCourseByIdRequest): Mono<CourseResponse> =
+        courseRepository.findById(id)
+            .switchIfEmpty(Mono.error(CourseNotFoundException()))
+            .map { request.run { it.update(title, image, curriculumId) } }
+            .flatMap { courseRepository.save(it) }
+            .map { CourseResponse(it) }
 
-    suspend fun deleteCourseById(id: String) {
-        courseRepository.findById(id) ?: CourseNotFoundException()
-        courseRepository.deleteById(id)
-    }
+    fun deleteCourseById(id: String): Mono<Void> =
+        courseRepository.findById(id)
+            .switchIfEmpty(Mono.error(CourseNotFoundException()))
+            .flatMap { courseRepository.deleteById(id) }
 }

--- a/src/main/kotlin/com/quizit/quiz/service/CurriculumService.kt
+++ b/src/main/kotlin/com/quizit/quiz/service/CurriculumService.kt
@@ -6,48 +6,41 @@ import com.quizit.quiz.dto.request.UpdateCurriculumByIdRequest
 import com.quizit.quiz.dto.response.CurriculumResponse
 import com.quizit.quiz.exception.CurriculumNotFoundException
 import com.quizit.quiz.repository.CurriculumRepository
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @Service
 class CurriculumService(
     private val curriculumRepository: CurriculumRepository
 ) {
-    suspend fun getCurriculumById(id: String): CurriculumResponse =
-        curriculumRepository.findById(id)?.let { CurriculumResponse(it) } ?: throw CurriculumNotFoundException()
+    fun getCurriculumById(id: String): Mono<CurriculumResponse> =
+        curriculumRepository.findById(id)
+            .map { CurriculumResponse(it) }
 
-    fun getCurriculums(): Flow<CurriculumResponse> =
+    fun getCurriculums(): Flux<CurriculumResponse> =
         curriculumRepository.findAll()
             .map { CurriculumResponse(it) }
 
-    suspend fun createCurriculum(request: CreateCurriculumRequest): CurriculumResponse =
+    fun createCurriculum(request: CreateCurriculumRequest): Mono<CurriculumResponse> =
         with(request) {
             curriculumRepository.save(
                 Curriculum(
                     title = title,
                     image = image
                 )
-            ).let { CurriculumResponse(it) }
+            ).map { CurriculumResponse(it) }
         }
 
-    suspend fun updateCurriculumById(id: String, request: UpdateCurriculumByIdRequest): CurriculumResponse =
-        with(request) {
-            curriculumRepository.findById(id)?.let {
-                curriculumRepository.save(
-                    Curriculum(
-                        id = id,
-                        title = title,
-                        image = image
-                    )
-                )
-            }?.let {
-                CurriculumResponse(it)
-            } ?: throw CurriculumNotFoundException()
-        }
+    fun updateCurriculumById(id: String, request: UpdateCurriculumByIdRequest): Mono<CurriculumResponse> =
+        curriculumRepository.findById(id)
+            .switchIfEmpty(Mono.error(CurriculumNotFoundException()))
+            .map { request.run { it.update(title, image) } }
+            .flatMap { curriculumRepository.save(it) }
+            .map { CurriculumResponse(it) }
 
-    suspend fun deleteCurriculumById(id: String) {
-        curriculumRepository.findById(id) ?: CurriculumNotFoundException()
-        curriculumRepository.deleteById(id)
-    }
+    fun deleteCurriculumById(id: String): Mono<Void> =
+        curriculumRepository.findById(id)
+            .switchIfEmpty(Mono.error(CurriculumNotFoundException()))
+            .flatMap { curriculumRepository.deleteById(id) }
 }

--- a/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
@@ -14,15 +14,15 @@ import com.quizit.quiz.dto.response.QuizResponse
 import com.quizit.quiz.exception.PermissionDeniedException
 import com.quizit.quiz.exception.QuizNotFoundException
 import com.quizit.quiz.global.config.isAdmin
+import com.quizit.quiz.global.util.component1
+import com.quizit.quiz.global.util.component2
 import com.quizit.quiz.repository.QuizCacheRepository
 import com.quizit.quiz.repository.QuizRepository
-import kotlinx.coroutines.async
-import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.launch
 import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Service
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.core.scheduler.Schedulers
 
 @Service
 class QuizService(
@@ -31,32 +31,35 @@ class QuizService(
     private val userClient: UserClient,
     private val quizProducer: QuizProducer
 ) {
-    suspend fun getQuizById(id: String): QuizResponse =
-        quizCacheRepository.findById(id)?.let { QuizResponse(it) } ?: throw QuizNotFoundException()
+    fun getQuizById(id: String): Mono<QuizResponse> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .map { QuizResponse(it) }
 
     fun getQuizzesByChapterIdAndAnswerRateRange(
         chapterId: String, answerRateRange: Set<Double>, pageable: Pageable
-    ): Flow<QuizResponse> =
+    ): Flux<QuizResponse> =
         with(answerRateRange) {
             quizRepository.findAllByChapterIdAndAnswerRateBetween(chapterId, min(), max(), pageable)
                 .map { QuizResponse(it) }
         }
 
-    fun getQuizzesByWriterId(writerId: String): Flow<QuizResponse> =
+    fun getQuizzesByWriterId(writerId: String): Flux<QuizResponse> =
         quizRepository.findAllByWriterId(writerId)
             .map { QuizResponse(it) }
 
-    fun getQuizzesByQuestionContains(keyword: String): Flow<QuizResponse> =
+    fun getQuizzesByQuestionContains(keyword: String): Flux<QuizResponse> =
         quizRepository.findAllByQuestionContains(keyword)
             .map { QuizResponse(it) }
 
-    suspend fun getMarkedQuizzes(userId: String): Flow<QuizResponse> =
-        quizRepository.findAllByIdIn(userClient.getUserById(userId).markedQuizIds.toList())
+    fun getMarkedQuizzes(userId: String): Flux<QuizResponse> =
+        userClient.getUserById(userId)
+            .flatMapMany { quizRepository.findAllByIdIn(it.markedQuizIds.toList()) }
             .map { QuizResponse(it) }
 
-    suspend fun createQuiz(userId: String, request: CreateQuizRequest): QuizResponse =
-        coroutineScope {
-            with(request) {
+    fun createQuiz(userId: String, request: CreateQuizRequest): Mono<QuizResponse> =
+        with(request) {
+            quizRepository.save(
                 Quiz(
                     question = question,
                     answer = answer,
@@ -67,149 +70,152 @@ class QuizService(
                     answerRate = 0.0,
                     correctCount = 0,
                     incorrectCount = 0,
-                    markedUserIds = mutableSetOf(),
-                    likedUserIds = mutableSetOf(),
-                    unlikedUserIds = mutableSetOf()
-                ).let {
-                    val quizDeferred = async { quizRepository.save(it) }
-                    val cacheJob = launch { quizCacheRepository.save(it) }
-
-                    cacheJob.join()
-                    quizDeferred.await()
-                }
-            }.let { QuizResponse(it) }
+                    markedUserIds = hashSetOf(),
+                    likedUserIds = hashSetOf(),
+                    unlikedUserIds = hashSetOf()
+                )
+            ).flatMap {
+                quizCacheRepository.save(it)
+                    .thenReturn(it)
+            }.map { QuizResponse(it) }
         }
 
-    suspend fun updateQuizById(
+    fun updateQuizById(
         id: String, authentication: DefaultJwtAuthentication, request: UpdateQuizByIdRequest
-    ): QuizResponse =
-        coroutineScope {
-            with(request) {
-                quizCacheRepository.findById(id)?.let {
-                    if ((authentication.id == it.writerId) || authentication.isAdmin()) {
-                        Quiz(
-                            id = id,
-                            question = question,
-                            answer = answer,
-                            solution = solution,
-                            writerId = it.writerId,
-                            chapterId = chapterId,
-                            options = options,
-                            answerRate = it.answerRate,
-                            correctCount = it.correctCount,
-                            incorrectCount = it.incorrectCount,
-                            markedUserIds = it.markedUserIds,
-                            likedUserIds = it.likedUserIds,
-                            unlikedUserIds = it.unlikedUserIds,
-                            createdDate = it.createdDate
-                        ).apply {
-                            val quizJob = launch { quizRepository.save(it) }
-                            val cacheJob = launch { quizCacheRepository.save(it) }
-
-                            quizJob.join()
-                            cacheJob.join()
-                        }
-                    } else throw PermissionDeniedException()
-                }?.let { QuizResponse(it) } ?: throw QuizNotFoundException()
+    ): Mono<QuizResponse> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .filter { (authentication.id == it.writerId) || authentication.isAdmin() }
+            .switchIfEmpty(Mono.error(PermissionDeniedException()))
+            .map { request.run { it.update(question, answer, solution, chapterId, options) } }
+            .flatMap {
+                Mono.zip(
+                    quizRepository.save(it)
+                        .subscribeOn(Schedulers.parallel()),
+                    quizCacheRepository.save(it)
+                        .subscribeOn(Schedulers.parallel())
+                )
             }
-        }
+            .map { (quiz) -> QuizResponse(quiz) }
 
-    suspend fun deleteQuizById(id: String, authentication: DefaultJwtAuthentication) =
-        coroutineScope {
-            quizCacheRepository.findById(id)?.let {
-                if ((authentication.id == it.writerId) || authentication.isAdmin()) {
-                    val quizJob = launch { quizRepository.deleteById(id) }
-                    val cacheJob = launch { quizCacheRepository.deleteById(id) }
+    fun deleteQuizById(id: String, authentication: DefaultJwtAuthentication): Mono<Void> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .filter { (authentication.id == it.writerId) || authentication.isAdmin() }
+            .switchIfEmpty(Mono.error(PermissionDeniedException()))
+            .flatMap {
+                Mono.`when`(
+                    quizRepository.deleteById(id)
+                        .subscribeOn(Schedulers.parallel()),
+                    quizCacheRepository.deleteById(id)
+                        .subscribeOn(Schedulers.parallel())
+                )
+            }
 
-                    quizJob.join()
-                    cacheJob.join()
-                } else throw PermissionDeniedException()
-            } ?: throw QuizNotFoundException()
-        }
+    fun checkAnswer(id: String, userId: String, request: CheckAnswerRequest): Mono<CheckAnswerResponse> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .cache()
+            .run {
+                subscribeOn(Schedulers.parallel())
+                    .zipWith(
+                        userClient.getUserById(userId)
+                            .subscribeOn(Schedulers.parallel())
+                    )
+                    .filter { (_, userResponse) -> (id !in userResponse.correctQuizIds) && (id !in userResponse.incorrectQuizIds) }
+                    .flatMap { (quiz) ->
+                        quiz.run {
+                            quizProducer.checkAnswer(
+                                CheckAnswerEvent(
+                                    userId = userId,
+                                    quizId = id,
+                                    isAnswer = (request.answer == answer)
+                                ).apply {
+                                    if (isAnswer) {
+                                        correctAnswer()
+                                    } else {
+                                        incorrectAnswer()
+                                    }
+                                }
+                            )
+                        }.thenReturn(quiz)
+                    }
+                    .flatMap {
+                        Mono.zip(
+                            quizRepository.save(it)
+                                .subscribeOn(Schedulers.parallel()),
+                            quizCacheRepository.save(it)
+                                .subscribeOn(Schedulers.parallel())
+                        )
+                    }
+                    .then(map {
+                        CheckAnswerResponse(
+                            answer = it.answer,
+                            solution = it.solution
+                        )
+                    })
+            }
 
-    suspend fun checkAnswer(id: String, userId: String, request: CheckAnswerRequest): CheckAnswerResponse =
-        coroutineScope {
-            val quizDeferred = async { quizCacheRepository.findById(id) ?: throw QuizNotFoundException() }
-            val userResponseDeferred = async { userClient.getUserById(userId) }
-            val quiz = quizDeferred.await()
-            val userResponse = userResponseDeferred.await()
-
-            quiz.apply {
-                if ((id !in userResponse.correctQuizIds) && (id !in userResponse.incorrectQuizIds)) {
-                    quizProducer.checkAnswer(
-                        CheckAnswerEvent(
+    fun markQuiz(id: String, userId: String): Mono<QuizResponse> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .flatMap {
+                it.run {
+                    quizProducer.markQuiz(
+                        MarkQuizEvent(
                             userId = userId,
                             quizId = id,
-                            isAnswer = (request.answer == answer)
+                            isMarked = (userId !in markedUserIds)
                         ).apply {
-                            if (isAnswer) {
-                                correctAnswer()
+                            if (isMarked) {
+                                mark(userId)
                             } else {
-                                incorrectAnswer()
+                                unmark(userId)
                             }
                         }
                     )
-                    val quizJob = launch { quizRepository.save(this@apply) }
-                    val cacheJob = launch { quizCacheRepository.save(this@apply) }
-
-                    quizJob.join()
-                    cacheJob.join()
-                }
-            }.run {
-                CheckAnswerResponse(
-                    answer = answer,
-                    solution = solution
+                }.thenReturn(it)
+            }
+            .flatMap {
+                Mono.zip(
+                    quizRepository.save(it)
+                        .subscribeOn(Schedulers.parallel()),
+                    quizCacheRepository.save(it)
+                        .subscribeOn(Schedulers.parallel())
                 )
             }
-        }
+            .map { (quiz) -> QuizResponse(quiz) }
 
-    suspend fun markQuiz(id: String, userId: String): QuizResponse =
-        coroutineScope {
-            quizCacheRepository.findById(id)?.apply {
-                quizProducer.markQuiz(
-                    MarkQuizEvent(
-                        userId = userId,
-                        quizId = id,
-                        isMarked = (userId !in markedUserIds)
-                    ).apply {
-                        if (isMarked) {
-                            mark(userId)
+    fun evaluateQuiz(id: String, userId: String, isLike: Boolean): Mono<QuizResponse> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .map {
+                it.apply {
+                    if (isLike) {
+                        if (userId in likedUserIds) {
+                            likedUserIds.remove(userId)
                         } else {
-                            unmark(userId)
+                            unlikedUserIds.remove(userId)
+                            like(userId)
+                        }
+                    } else {
+                        if (userId in unlikedUserIds) {
+                            unlikedUserIds.remove(userId)
+                        } else {
+                            likedUserIds.remove(userId)
+                            unlike(userId)
                         }
                     }
-                )
-                val quizJob = launch { quizRepository.save(this@apply) }
-                val cacheJob = launch { quizCacheRepository.save(this@apply) }
-
-                quizJob.join()
-                cacheJob.join()
-            }?.let { QuizResponse(it) } ?: throw QuizNotFoundException()
-        }
-
-    suspend fun evaluateQuiz(id: String, userId: String, isLike: Boolean): QuizResponse =
-        coroutineScope {
-            quizCacheRepository.findById(id)?.apply {
-                if (isLike) {
-                    if (userId in likedUserIds) {
-                        likedUserIds.remove(userId)
-                    } else {
-                        unlikedUserIds.remove(userId)
-                        like(userId)
-                    }
-                } else {
-                    if (userId in unlikedUserIds) {
-                        unlikedUserIds.remove(userId)
-                    } else {
-                        likedUserIds.remove(userId)
-                        unlike(userId)
-                    }
                 }
-                val quizJob = launch { quizRepository.save(this@apply) }
-                val cacheJob = launch { quizCacheRepository.save(this@apply) }
+            }
+            .flatMap {
+                Mono.zip(
+                    quizRepository.save(it)
+                        .subscribeOn(Schedulers.parallel()),
+                    quizCacheRepository.save(it)
+                        .subscribeOn(Schedulers.parallel())
+                )
+            }
+            .map { (quiz) -> QuizResponse(quiz) }
 
-                quizJob.join()
-                cacheJob.join()
-            }?.let { QuizResponse(it) } ?: throw QuizNotFoundException()
-        }
 }

--- a/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
@@ -217,5 +217,4 @@ class QuizService(
                 )
             }
             .map { (quiz) -> QuizResponse(quiz) }
-
 }

--- a/src/test/kotlin/com/quizit/quiz/controller/ChapterControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/ChapterControllerTest.kt
@@ -13,15 +13,14 @@ import com.quizit.quiz.handler.ChapterHandler
 import com.quizit.quiz.router.ChapterRouter
 import com.quizit.quiz.service.ChapterService
 import com.quizit.quiz.util.*
-import io.mockk.coEvery
-import io.mockk.just
-import io.mockk.runs
-import kotlinx.coroutines.flow.flowOf
+import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @WebFluxTest(ChapterRouter::class, ChapterHandler::class)
 class ChapterControllerTest : BaseControllerTest() {
@@ -52,7 +51,7 @@ class ChapterControllerTest : BaseControllerTest() {
     init {
         describe("getChapterById()는") {
             context("챕터가 존재하는 경우") {
-                coEvery { chapterService.getChapterById(any()) } returns createChapterResponse()
+                every { chapterService.getChapterById(any()) } returns Mono.just(createChapterResponse())
                 withMockUser()
 
                 it("상태 코드 200과 chapterResponse를 반환한다.") {
@@ -76,7 +75,7 @@ class ChapterControllerTest : BaseControllerTest() {
             }
 
             context("챕터가 존재하지 않는 경우") {
-                coEvery { chapterService.getChapterById(any()) } throws ChapterNotFoundException()
+                every { chapterService.getChapterById(any()) } throws ChapterNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404를 반환한다.") {
@@ -102,7 +101,7 @@ class ChapterControllerTest : BaseControllerTest() {
 
         describe("getChaptersByCourseId()는") {
             context("코스와 각각의 코스에 속하는 챕터들이 존재하는 경우") {
-                coEvery { chapterService.getChaptersByCourseId(any()) } returns flowOf(createChapterResponse())
+                every { chapterService.getChaptersByCourseId(any()) } returns Flux.just(createChapterResponse())
                 withMockUser()
 
                 it("상태 코드 200과 chapterResponse들을 반환한다.") {
@@ -128,7 +127,7 @@ class ChapterControllerTest : BaseControllerTest() {
 
         describe("createChapter()는") {
             context("어드민이 챕터를 작성해서 제출하는 경우") {
-                coEvery { chapterService.createChapter(any()) } returns createChapterResponse()
+                every { chapterService.createChapter(any()) } returns Mono.just(createChapterResponse())
                 withMockAdmin()
 
                 it("상태 코드 200과 chapterResponse를 반환한다.") {
@@ -155,7 +154,7 @@ class ChapterControllerTest : BaseControllerTest() {
 
         describe("updateChapterById()는") {
             context("어드민이 챕터를 수정해서 제출하는 경우") {
-                coEvery { chapterService.updateChapterById(any(), any()) } returns createChapterResponse()
+                every { chapterService.updateChapterById(any(), any()) } returns Mono.just(createChapterResponse())
                 withMockAdmin()
 
                 it("상태 코드 200과 chapterResponse를 반환한다.") {
@@ -180,7 +179,7 @@ class ChapterControllerTest : BaseControllerTest() {
             }
 
             context("챕터가 존재하지 않는 경우") {
-                coEvery { chapterService.updateChapterById(any(), any()) } throws ChapterNotFoundException()
+                every { chapterService.updateChapterById(any(), any()) } throws ChapterNotFoundException()
                 withMockAdmin()
 
                 it("상태 코드 404를 반환한다.") {
@@ -207,7 +206,7 @@ class ChapterControllerTest : BaseControllerTest() {
 
         describe("deleteChapterById()는") {
             context("어드민이 챕터를 삭제하는 경우") {
-                coEvery { chapterService.deleteChapterById(any()) } just runs
+                every { chapterService.deleteChapterById(any()) } returns Mono.empty()
                 withMockAdmin()
 
                 it("상태 코드 200을 반환한다.") {
@@ -230,7 +229,7 @@ class ChapterControllerTest : BaseControllerTest() {
             }
 
             context("챕터가 존재하지 않는 경우") {
-                coEvery { chapterService.deleteChapterById(any()) } throws ChapterNotFoundException()
+                every { chapterService.deleteChapterById(any()) } throws ChapterNotFoundException()
                 withMockAdmin()
 
                 it("상태 코드 404을 반환한다.") {

--- a/src/test/kotlin/com/quizit/quiz/controller/CourseControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/CourseControllerTest.kt
@@ -13,15 +13,14 @@ import com.quizit.quiz.handler.CourseHandler
 import com.quizit.quiz.router.CourseRouter
 import com.quizit.quiz.service.CourseService
 import com.quizit.quiz.util.*
-import io.mockk.coEvery
-import io.mockk.just
-import io.mockk.runs
-import kotlinx.coroutines.flow.flowOf
+import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @WebFluxTest(CourseRouter::class, CourseHandler::class)
 class CourseControllerTest : BaseControllerTest() {
@@ -52,7 +51,7 @@ class CourseControllerTest : BaseControllerTest() {
     init {
         describe("getCourseById()는") {
             context("코스가 존재하는 경우") {
-                coEvery { courseService.getCourseById(any()) } returns createCourseResponse()
+                every { courseService.getCourseById(any()) } returns Mono.just(createCourseResponse())
                 withMockUser()
 
                 it("상태 코드 200과 courseResponse를 반환한다.") {
@@ -75,7 +74,7 @@ class CourseControllerTest : BaseControllerTest() {
             }
 
             context("코스가 존재하지 않는 경우") {
-                coEvery { courseService.getCourseById(any()) } throws CourseNotFoundException()
+                every { courseService.getCourseById(any()) } throws CourseNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404를 반환한다.") {
@@ -100,7 +99,7 @@ class CourseControllerTest : BaseControllerTest() {
 
         describe("getCoursesByCurriculumId()는") {
             context("커리큘럼과 각각의 커리큘럼에 속하는 코스들이 존재하는 경우") {
-                coEvery { courseService.getCoursesByCurriculumId(any()) } returns flowOf(createCourseResponse())
+                every { courseService.getCoursesByCurriculumId(any()) } returns Flux.just(createCourseResponse())
                 withMockUser()
 
                 it("상태 코드 200과 courseResponse들을 반환한다.") {
@@ -125,7 +124,7 @@ class CourseControllerTest : BaseControllerTest() {
 
         describe("createCourse()는") {
             context("어드민이 코스를 작성해서 제출하는 경우") {
-                coEvery { courseService.createCourse(any()) } returns createCourseResponse()
+                every { courseService.createCourse(any()) } returns Mono.just(createCourseResponse())
                 withMockAdmin()
 
                 it("상태 코드 200과 courseResponse를 반환한다.") {
@@ -152,7 +151,7 @@ class CourseControllerTest : BaseControllerTest() {
 
         describe("updateCourseById()는") {
             context("어드민이 코스를 수정해서 제출하는 경우") {
-                coEvery { courseService.updateCourseById(any(), any()) } returns createCourseResponse()
+                every { courseService.updateCourseById(any(), any()) } returns Mono.just(createCourseResponse())
                 withMockAdmin()
 
                 it("상태 코드 200과 courseResponse를 반환한다.") {
@@ -177,7 +176,7 @@ class CourseControllerTest : BaseControllerTest() {
             }
 
             context("코스가 존재하지 않는 경우") {
-                coEvery { courseService.updateCourseById(any(), any()) } throws CourseNotFoundException()
+                every { courseService.updateCourseById(any(), any()) } throws CourseNotFoundException()
                 withMockAdmin()
 
                 it("상태 코드 404를 반환한다.") {
@@ -204,7 +203,7 @@ class CourseControllerTest : BaseControllerTest() {
 
         describe("deleteCourseById()는") {
             context("어드민이 코스를 삭제하는 경우") {
-                coEvery { courseService.deleteCourseById(any()) } just runs
+                every { courseService.deleteCourseById(any()) } returns Mono.empty()
                 withMockAdmin()
 
                 it("상태 코드 200을 반환한다.") {
@@ -227,7 +226,7 @@ class CourseControllerTest : BaseControllerTest() {
             }
 
             context("코스가 존재하지 않는 경우") {
-                coEvery { courseService.deleteCourseById(any()) } throws CourseNotFoundException()
+                every { courseService.deleteCourseById(any()) } throws CourseNotFoundException()
                 withMockAdmin()
 
                 it("상태 코드 404를 반환한다.") {

--- a/src/test/kotlin/com/quizit/quiz/controller/CurriculumControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/CurriculumControllerTest.kt
@@ -13,15 +13,14 @@ import com.quizit.quiz.handler.CurriculumHandler
 import com.quizit.quiz.router.CurriculumRouter
 import com.quizit.quiz.service.CurriculumService
 import com.quizit.quiz.util.*
-import io.mockk.coEvery
-import io.mockk.just
-import io.mockk.runs
-import kotlinx.coroutines.flow.flowOf
+import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @WebFluxTest(CurriculumRouter::class, CurriculumHandler::class)
 class CurriculumControllerTest : BaseControllerTest() {
@@ -50,7 +49,7 @@ class CurriculumControllerTest : BaseControllerTest() {
     init {
         describe("getCurriculumById()는") {
             context("커리큘럼이 존재하는 경우") {
-                coEvery { curriculumService.getCurriculumById(any()) } returns createCurriculumResponse()
+                every { curriculumService.getCurriculumById(any()) } returns Mono.just(createCurriculumResponse())
                 withMockUser()
 
                 it("상태 코드 200과 curriculumResponse를 반환한다.") {
@@ -73,7 +72,7 @@ class CurriculumControllerTest : BaseControllerTest() {
             }
 
             context("커리큘럼이 존재하지 않는 경우") {
-                coEvery { curriculumService.getCurriculumById(any()) } throws CurriculumNotFoundException()
+                every { curriculumService.getCurriculumById(any()) } throws CurriculumNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404를 반환한다.") {
@@ -98,7 +97,7 @@ class CurriculumControllerTest : BaseControllerTest() {
 
         describe("getCurriculums()는") {
             context("커리큘럼들이 존재하는 경우") {
-                coEvery { curriculumService.getCurriculums() } returns flowOf(createCurriculumResponse())
+                every { curriculumService.getCurriculums() } returns Flux.just(createCurriculumResponse())
                 withMockUser()
 
                 it("상태 코드 200과 curriculumResponse들을 반환한다.") {
@@ -123,7 +122,7 @@ class CurriculumControllerTest : BaseControllerTest() {
 
         describe("createCurriculum()는") {
             context("어드민이 챕터를 작성해서 제출하는 경우") {
-                coEvery { curriculumService.createCurriculum(any()) } returns createCurriculumResponse()
+                every { curriculumService.createCurriculum(any()) } returns Mono.just(createCurriculumResponse())
                 withMockAdmin()
 
                 it("상태 코드 200과 curriculumResponse를 반환한다.") {
@@ -150,7 +149,9 @@ class CurriculumControllerTest : BaseControllerTest() {
 
         describe("updateCurriculumById()는") {
             context("어드민이 커리큘럼을 수정해서 제출하는 경우") {
-                coEvery { curriculumService.updateCurriculumById(any(), any()) } returns createCurriculumResponse()
+                every { curriculumService.updateCurriculumById(any(), any()) } returns Mono.just(
+                    createCurriculumResponse()
+                )
                 withMockAdmin()
 
                 it("상태 코드 200과 curriculumResponse를 반환한다.") {
@@ -175,7 +176,7 @@ class CurriculumControllerTest : BaseControllerTest() {
             }
 
             context("커리큘럼이 존재하지 않는 경우") {
-                coEvery { curriculumService.updateCurriculumById(any(), any()) } throws CurriculumNotFoundException()
+                every { curriculumService.updateCurriculumById(any(), any()) } throws CurriculumNotFoundException()
                 withMockAdmin()
 
                 it("상태 코드 404를 반환한다.") {
@@ -202,7 +203,7 @@ class CurriculumControllerTest : BaseControllerTest() {
 
         describe("deleteCurriculumById()는") {
             context("어드민이 챕터를 삭제하는 경우") {
-                coEvery { curriculumService.deleteCurriculumById(any()) } just runs
+                every { curriculumService.deleteCurriculumById(any()) } returns Mono.empty()
                 withMockAdmin()
 
                 it("상태 코드 200을 반환한다.") {
@@ -225,7 +226,7 @@ class CurriculumControllerTest : BaseControllerTest() {
             }
 
             context("어드민이 챕터를 삭제하는 경우") {
-                coEvery { curriculumService.deleteCurriculumById(any()) } throws CurriculumNotFoundException()
+                every { curriculumService.deleteCurriculumById(any()) } throws CurriculumNotFoundException()
                 withMockAdmin()
 
                 it("상태 코드 404를 반환한다.") {

--- a/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
@@ -12,16 +12,15 @@ import com.quizit.quiz.handler.QuizHandler
 import com.quizit.quiz.router.QuizRouter
 import com.quizit.quiz.service.QuizService
 import com.quizit.quiz.util.*
-import io.mockk.coEvery
-import io.mockk.just
-import io.mockk.runs
-import kotlinx.coroutines.flow.flowOf
+import io.mockk.every
 import org.springframework.boot.test.autoconfigure.web.reactive.WebFluxTest
 import org.springframework.restdocs.operation.preprocess.Preprocessors
 import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
 import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
 import org.springframework.restdocs.request.RequestDocumentation.queryParameters
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
 
 @WebFluxTest(QuizRouter::class, QuizHandler::class)
 class QuizControllerTest : BaseControllerTest() {
@@ -73,7 +72,7 @@ class QuizControllerTest : BaseControllerTest() {
     init {
         describe("getQuizById()는") {
             context("퀴즈가 존재하는 경우") {
-                coEvery { quizService.getQuizById(any()) } returns createQuizResponse()
+                every { quizService.getQuizById(any()) } returns Mono.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse를 반환한다.") {
@@ -97,7 +96,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("퀴즈가 존재하지 않는 경우") {
-                coEvery { quizService.getQuizById(any()) } throws QuizNotFoundException()
+                every { quizService.getQuizById(any()) } throws QuizNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404를 반환한다.") {
@@ -123,9 +122,9 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("getQuizzesByChapterIdAndAnswerRateRange()는") {
             context("챕터와 각각의 챕터에 속하는 퀴즈들이 존재하는 경우") {
-                coEvery {
+                every {
                     quizService.getQuizzesByChapterIdAndAnswerRateRange(any(), any(), any())
-                } returns flowOf(createQuizResponse())
+                } returns Flux.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
@@ -156,7 +155,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("getQuizzesByWriterId()는") {
             context("유저가 작성한 퀴즈가 존재하는 경우") {
-                coEvery { quizService.getQuizzesByWriterId(any()) } returns flowOf(createQuizResponse())
+                every { quizService.getQuizzesByWriterId(any()) } returns Flux.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
@@ -182,7 +181,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("getQuizzesByQuestionContains()는") {
             context("주어진 키워드를 문제 지문에 포함하는 퀴즈가 존재하는 경우") {
-                coEvery { quizService.getQuizzesByQuestionContains(any()) } returns flowOf(createQuizResponse())
+                every { quizService.getQuizzesByQuestionContains(any()) } returns Flux.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
@@ -208,7 +207,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("getMarkedQuizzes()는") {
             context("유저가 저장한 퀴즈가 존재하는 경우") {
-                coEvery { quizService.getMarkedQuizzes(any()) } returns flowOf(createQuizResponse())
+                every { quizService.getMarkedQuizzes(any()) } returns Flux.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse들을 반환한다.") {
@@ -233,7 +232,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("createQuiz()는") {
             context("유저가 퀴즈를 작성해서 제출하는 경우") {
-                coEvery { quizService.createQuiz(any(), any()) } returns createQuizResponse()
+                every { quizService.createQuiz(any(), any()) } returns Mono.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse를 반환한다.") {
@@ -260,7 +259,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("updateQuizById()는") {
             context("유저가 퀴즈를 수정해서 제출하는 경우") {
-                coEvery { quizService.updateQuizById(any(), any(), any()) } returns createQuizResponse()
+                every { quizService.updateQuizById(any(), any(), any()) } returns Mono.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200과 quizResponse를 반환한다.") {
@@ -285,7 +284,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("퀴즈가 존재하지 않는 경우") {
-                coEvery { quizService.updateQuizById(any(), any(), any()) } throws QuizNotFoundException()
+                every { quizService.updateQuizById(any(), any(), any()) } throws QuizNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404를 반환한다.") {
@@ -310,7 +309,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("유저가 다른 유저의 퀴즈를 수정해서 제출하는 경우") {
-                coEvery { quizService.updateQuizById(any(), any(), any()) } throws PermissionDeniedException()
+                every { quizService.updateQuizById(any(), any(), any()) } throws PermissionDeniedException()
                 withMockUser()
 
                 it("상태 코드 403을 반환한다.") {
@@ -337,7 +336,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("deleteQuizById()는") {
             context("유저가 퀴즈를 삭제하는 경우") {
-                coEvery { quizService.deleteQuizById(any(), any()) } just runs
+                every { quizService.deleteQuizById(any(), any()) } returns Mono.empty()
                 withMockUser()
 
                 it("상태 코드 200을 반환한다.") {
@@ -360,7 +359,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("퀴즈가 존재하지 않는 경우") {
-                coEvery { quizService.deleteQuizById(any(), any()) } throws QuizNotFoundException()
+                every { quizService.deleteQuizById(any(), any()) } throws QuizNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404를 반환한다.") {
@@ -384,7 +383,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("유저가 다른 유저의 퀴즈를 삭제하는 경우") {
-                coEvery { quizService.deleteQuizById(any(), any()) } throws PermissionDeniedException()
+                every { quizService.deleteQuizById(any(), any()) } throws PermissionDeniedException()
                 withMockUser()
 
                 it("상태 코드 403을 반환한다.") {
@@ -410,7 +409,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("checkQuiz()는") {
             context("유저가 퀴즈 답을 제출한 경우") {
-                coEvery { quizService.checkAnswer(any(), any(), any()) } returns createCheckAnswerResponse()
+                every { quizService.checkAnswer(any(), any(), any()) } returns Mono.just(createCheckAnswerResponse())
                 withMockUser()
 
                 it("상태 코드 200과 정답 여부가 담긴 checkAnswerResponse를 반환한다.") {
@@ -435,7 +434,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("퀴즈가 존재하지 않는 경우") {
-                coEvery { quizService.checkAnswer(any(), any(), any()) } throws QuizNotFoundException()
+                every { quizService.checkAnswer(any(), any(), any()) } throws QuizNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404과 에러를 반환한다.") {
@@ -462,7 +461,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("markQuiz()는") {
             context("주어진 퀴즈 식별자에 대한 퀴즈가 존재하는 경우") {
-                coEvery { quizService.markQuiz(any(), any()) } returns createQuizResponse()
+                every { quizService.markQuiz(any(), any()) } returns Mono.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200을 반환한다.") {
@@ -486,7 +485,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("주어진 퀴즈 식별자에 대한 퀴즈가 존재하지 않는 경우") {
-                coEvery { quizService.markQuiz(any(), any()) } throws QuizNotFoundException()
+                every { quizService.markQuiz(any(), any()) } throws QuizNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404과 에러를 반환한다.") {
@@ -512,7 +511,7 @@ class QuizControllerTest : BaseControllerTest() {
 
         describe("evaluateQuiz()는") {
             context("주어진 퀴즈 식별자에 대한 퀴즈가 존재하는 경우") {
-                coEvery { quizService.evaluateQuiz(any(), any(), any()) } returns createQuizResponse()
+                every { quizService.evaluateQuiz(any(), any(), any()) } returns Mono.just(createQuizResponse())
                 withMockUser()
 
                 it("상태 코드 200을 반환한다.") {
@@ -537,7 +536,7 @@ class QuizControllerTest : BaseControllerTest() {
             }
 
             context("주어진 퀴즈 식별자에 대한 퀴즈가 존재하지 않는 경우") {
-                coEvery { quizService.evaluateQuiz(any(), any(), any()) } throws QuizNotFoundException()
+                every { quizService.evaluateQuiz(any(), any(), any()) } throws QuizNotFoundException()
                 withMockUser()
 
                 it("상태 코드 404과 에러를 반환한다.") {

--- a/src/test/kotlin/com/quizit/quiz/domain/ChapterTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/domain/ChapterTest.kt
@@ -1,0 +1,30 @@
+package com.quizit.quiz.domain
+
+import com.quizit.quiz.fixture.DESCRIPTION
+import com.quizit.quiz.fixture.DOCUMENT
+import com.quizit.quiz.fixture.ID
+import com.quizit.quiz.fixture.createChapter
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+
+class ChapterTest : BehaviorSpec() {
+    init {
+        Given("챕터가 존재하는 경우") {
+            val chapter = createChapter()
+                .apply {
+                    description = DESCRIPTION
+                    document = DOCUMENT
+                    courseId = ID
+                } // Code Coverage
+
+            When("어드민이 챕터를 수정하면") {
+                val updatedChapter = createChapter(description = "updated_description")
+                    .apply { update(description, document, courseId) }
+
+                Then("챕터가 수정된다.") {
+                    updatedChapter shouldNotBeEqualToComparingFields chapter
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/quizit/quiz/domain/CourseTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/domain/CourseTest.kt
@@ -1,0 +1,30 @@
+package com.quizit.quiz.domain
+
+import com.quizit.quiz.fixture.ID
+import com.quizit.quiz.fixture.IMAGE
+import com.quizit.quiz.fixture.TITLE
+import com.quizit.quiz.fixture.createCourse
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+
+class CourseTest : BehaviorSpec() {
+    init {
+        Given("코스가 존재하는 경우") {
+            val course = createCourse()
+                .apply {
+                    title = TITLE
+                    image = IMAGE
+                    curriculumId = ID
+                } // Code Coverage
+
+            When("어드민이 코스를 수정하면") {
+                val updatedCourse = createCourse(title = "updated_title")
+                    .apply { update(title, image, curriculumId) }
+
+                Then("코스가 수정된다.") {
+                    updatedCourse shouldNotBeEqualToComparingFields course
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/quizit/quiz/domain/CurriculumTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/domain/CurriculumTest.kt
@@ -1,0 +1,28 @@
+package com.quizit.quiz.domain
+
+import com.quizit.quiz.fixture.IMAGE
+import com.quizit.quiz.fixture.TITLE
+import com.quizit.quiz.fixture.createCurriculum
+import io.kotest.core.spec.style.BehaviorSpec
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+
+class CurriculumTest : BehaviorSpec() {
+    init {
+        Given("커리큘럼이 존재하는 경우") {
+            val curriculum = createCurriculum()
+                .apply {
+                    title = TITLE
+                    image = IMAGE
+                } // Code Coverage
+
+            When("어드민이 커리큘럼을 수정하면") {
+                val updatedCurriculum = createCurriculum(title = "updated_title")
+                    .apply { update(title, image) }
+
+                Then("커리큘럼이 수정된다.") {
+                    updatedCurriculum shouldNotBeEqualToComparingFields curriculum
+                }
+            }
+        }
+    }
+}

--- a/src/test/kotlin/com/quizit/quiz/domain/QuizTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/domain/QuizTest.kt
@@ -1,23 +1,32 @@
 package com.quizit.quiz.domain
 
-import com.quizit.quiz.fixture.ID
-import com.quizit.quiz.fixture.createQuiz
+import com.quizit.quiz.fixture.*
 import io.kotest.core.spec.style.BehaviorSpec
 import io.kotest.matchers.doubles.shouldBeGreaterThan
 import io.kotest.matchers.doubles.shouldBeLessThan
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeLessThan
 
 class QuizTest : BehaviorSpec() {
     init {
         Given("퀴즈가 존재하는 경우") {
-            val quiz = createQuiz().apply {
-                incorrectCount = 0
-                correctCount = 0
-            } // Code Coverage
+            val quiz = createQuiz()
+                .apply {
+                    question = QUESTION
+                    answer = ANSWER
+                    solution = SOLUTION
+                    writerId = ID
+                    chapterId = ID
+                    options = OPTIONS
+                    answerRate = ANSWER_RATE
+                    correctCount = CORRECT_COUNT
+                    incorrectCount = INCORRECT_COUNT
+                } // Code Coverage
 
             When("유저가 해당 퀴즈의 정답을 맞췄다면") {
-                val increasedQuiz = createQuiz().apply { correctAnswer() }
+                val increasedQuiz = createQuiz()
+                    .apply { correctAnswer() }
 
                 Then("해당 퀴즈의 정답률이 상승한다.") {
                     increasedQuiz.answerRate shouldBeGreaterThan quiz.answerRate
@@ -25,7 +34,8 @@ class QuizTest : BehaviorSpec() {
             }
 
             When("유저가 해당 퀴즈의 정답을 틀렸다면") {
-                val decreasedQuiz = createQuiz().apply { incorrectAnswer() }
+                val decreasedQuiz = createQuiz()
+                    .apply { incorrectAnswer() }
 
                 Then("해당 퀴즈의 정답률이 감소한다.") {
                     decreasedQuiz.answerRate shouldBeLessThan quiz.answerRate
@@ -33,7 +43,8 @@ class QuizTest : BehaviorSpec() {
             }
 
             When("유저가 해당 퀴즈를 저장했다면") {
-                val markedQuiz = createQuiz().apply { mark(ID) }
+                val markedQuiz = createQuiz()
+                    .apply { mark(ID) }
 
                 Then("해당 퀴즈에 저장한 유저가 추가된다.") {
                     markedQuiz.markedUserIds.size shouldBeGreaterThan quiz.markedUserIds.size
@@ -41,7 +52,8 @@ class QuizTest : BehaviorSpec() {
             }
 
             When("유저가 해당 퀴즈를 저장 취소를 했다면") {
-                val unmarkedQuiz = createQuiz().apply { unmark(markedUserIds.random()) }
+                val unmarkedQuiz = createQuiz()
+                    .apply { unmark(markedUserIds.random()) }
 
                 Then("해당 퀴즈에 저장한 유저가 삭제된다.") {
                     unmarkedQuiz.markedUserIds.size shouldBeLessThan quiz.markedUserIds.size
@@ -49,7 +61,8 @@ class QuizTest : BehaviorSpec() {
             }
 
             When("유저가 해당 퀴즈를 좋아요로 평가했다면") {
-                val likedQuiz = createQuiz().apply { like(ID) }
+                val likedQuiz = createQuiz()
+                    .apply { like(ID) }
 
                 Then("해당 퀴즈에 좋아요한 유저가 추가된다.") {
                     likedQuiz.likedUserIds.size shouldBeGreaterThan quiz.likedUserIds.size
@@ -57,10 +70,20 @@ class QuizTest : BehaviorSpec() {
             }
 
             When("유저가 해당 퀴즈를 싫어요로 평가했다면") {
-                val unlikedQuiz = createQuiz().apply { unlike(ID) }
+                val unlikedQuiz = createQuiz()
+                    .apply { unlike(ID) }
 
                 Then("해당 퀴즈에 싫어요한 유저가 추가된다.") {
                     unlikedQuiz.unlikedUserIds.size shouldBeGreaterThan quiz.unlikedUserIds.size
+                }
+            }
+
+            When("유저가 퀴즈를 수정한다면") {
+                val updatedQuiz = createQuiz(question = "updated_question")
+                    .apply { update(question, answer, solution, chapterId, options) }
+
+                Then("퀴즈의 정보가 수정된다.") {
+                    updatedQuiz shouldNotBeEqualToComparingFields quiz
                 }
             }
         }

--- a/src/test/kotlin/com/quizit/quiz/fixture/ChapterFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/ChapterFixture.kt
@@ -5,8 +5,8 @@ import com.quizit.quiz.dto.request.CreateChapterRequest
 import com.quizit.quiz.dto.request.UpdateChapterByIdRequest
 import com.quizit.quiz.dto.response.ChapterResponse
 
-const val DESCRIPTION = "test"
-const val DOCUMENT = "test"
+const val DESCRIPTION = "description"
+const val DOCUMENT = "document"
 
 fun createCreateChapterRequest(
     description: String = DESCRIPTION,

--- a/src/test/kotlin/com/quizit/quiz/fixture/CourseFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/CourseFixture.kt
@@ -5,8 +5,7 @@ import com.quizit.quiz.dto.request.CreateCourseRequest
 import com.quizit.quiz.dto.request.UpdateCourseByIdRequest
 import com.quizit.quiz.dto.response.CourseResponse
 
-const val TITLE = "test"
-const val IMAGE = "test"
+const val TITLE = "title"
 
 fun createCreateCourseRequest(
     title: String = TITLE,

--- a/src/test/kotlin/com/quizit/quiz/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/JwtFixture.kt
@@ -10,7 +10,7 @@ const val ACCESS_TOKEN_EXPIRE = 5L
 const val REFRESH_TOKEN_EXPIRE = 10L
 val AUTHORITIES = listOf(SimpleGrantedAuthority("USER"))
 val jwtProvider = JwtConfiguration().jwtProvider(
-    secretKey = SECRET_KEY, accessTokenExpire = ACCESS_TOKEN_EXPIRE, refreshTokenExpire = REFRESH_TOKEN_EXPIRE
+    SECRET_KEY, ACCESS_TOKEN_EXPIRE, REFRESH_TOKEN_EXPIRE
 )
 
 fun createJwtAuthentication(

--- a/src/test/kotlin/com/quizit/quiz/fixture/JwtFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/JwtFixture.kt
@@ -2,13 +2,14 @@ package com.quizit.quiz.fixture
 
 import com.github.jwt.authentication.DefaultJwtAuthentication
 import com.github.jwt.config.JwtConfiguration
+import com.quizit.quiz.domain.enum.Role
 import org.springframework.security.core.GrantedAuthority
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 
 val SECRET_KEY = (1..100).map { ('a'..'z').random() }.joinToString("")
 const val ACCESS_TOKEN_EXPIRE = 5L
 const val REFRESH_TOKEN_EXPIRE = 10L
-val AUTHORITIES = listOf(SimpleGrantedAuthority("USER"))
+val AUTHORITIES = listOf(SimpleGrantedAuthority(Role.USER.name))
 val jwtProvider = JwtConfiguration().jwtProvider(
     SECRET_KEY, ACCESS_TOKEN_EXPIRE, REFRESH_TOKEN_EXPIRE
 )

--- a/src/test/kotlin/com/quizit/quiz/fixture/QuizFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/QuizFixture.kt
@@ -11,13 +11,13 @@ import java.time.LocalDateTime
 const val QUESTION = "question"
 const val ANSWER = 1
 const val SOLUTION = "solution"
-val OPTIONS = (0..4).map { "option_$it" }
+val OPTIONS = (0..4).map { "$it" }
 const val ANSWER_RATE = 50.0
 const val CORRECT_COUNT = 10L
 const val INCORRECT_COUNT = 10L
-val MARKED_USER_IDS = mutableSetOf("user_1")
-val LIKED_USER_IDS = mutableSetOf("user_1")
-val UNLIKED_USER_IDS = mutableSetOf("user_1")
+val MARKED_USER_IDS = hashSetOf("1")
+val LIKED_USER_IDS = hashSetOf("1")
+val UNLIKED_USER_IDS = hashSetOf("1")
 
 fun createCreateQuizRequest(
     question: String = QUESTION,
@@ -72,9 +72,9 @@ fun createQuizResponse(
     answerRate: Double = ANSWER_RATE,
     correctCount: Long = CORRECT_COUNT,
     incorrectCount: Long = INCORRECT_COUNT,
-    markedUserIds: Set<String> = MARKED_USER_IDS,
-    likedUserIds: MutableSet<String> = LIKED_USER_IDS,
-    unlikedUserIds: MutableSet<String> = UNLIKED_USER_IDS,
+    markedUserIds: HashSet<String> = MARKED_USER_IDS,
+    likedUserIds: HashSet<String> = LIKED_USER_IDS,
+    unlikedUserIds: HashSet<String> = UNLIKED_USER_IDS,
     createdDate: LocalDateTime = CREATED_DATE
 ): QuizResponse =
     QuizResponse(
@@ -103,9 +103,9 @@ fun createQuiz(
     answerRate: Double = ANSWER_RATE,
     correctCount: Long = CORRECT_COUNT,
     incorrectCount: Long = INCORRECT_COUNT,
-    markedUserIds: MutableSet<String> = MARKED_USER_IDS.toMutableSet(),
-    likedUserIds: MutableSet<String> = LIKED_USER_IDS.toMutableSet(),
-    unlikedUserIds: MutableSet<String> = UNLIKED_USER_IDS.toMutableSet(),
+    markedUserIds: HashSet<String> = MARKED_USER_IDS.toHashSet(),
+    likedUserIds: HashSet<String> = LIKED_USER_IDS.toHashSet(),
+    unlikedUserIds: HashSet<String> = UNLIKED_USER_IDS.toHashSet(),
     createdDate: LocalDateTime = CREATED_DATE
 ): Quiz = Quiz(
     id = id,

--- a/src/test/kotlin/com/quizit/quiz/fixture/UserFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/UserFixture.kt
@@ -1,17 +1,19 @@
 package com.quizit.quiz.fixture
 
+import com.quizit.quiz.domain.enum.Role
 import com.quizit.quiz.dto.response.UserResponse
 import java.time.LocalDateTime
 
-const val USERNAME = "test"
-const val NICKNAME = "test"
+const val USERNAME = "earlgrey02@github.com"
+const val NICKNAME = "earlgrey02"
+const val IMAGE = "http://localhost:8080/image.jpg"
 const val LEVEL = 2
-const val ROLE = "USER"
+val ROLE = Role.USER
 const val ALLOW_PUSH = true
 const val DAILY_TARGET = 10
-val CORRECT_QUIZ_IDS = setOf("quiz")
-val INCORRECT_QUIZ_IDS = setOf("quiz")
-val MARKED_QUIZ_IDS = setOf("quiz")
+val CORRECT_QUIZ_IDS = hashSetOf("1")
+val INCORRECT_QUIZ_IDS = hashSetOf("1")
+val MARKED_QUIZ_IDS = hashSetOf("1")
 
 fun createUserResponse(
     id: String = ID,
@@ -19,14 +21,14 @@ fun createUserResponse(
     nickname: String = NICKNAME,
     image: String = IMAGE,
     level: Int = LEVEL,
-    role: String = ROLE,
+    role: Role = ROLE,
     allowPush: Boolean = ALLOW_PUSH,
     dailyTarget: Int = DAILY_TARGET,
     answerRate: Double = ANSWER_RATE,
     createdDate: LocalDateTime = CREATED_DATE,
-    correctQuizIds: Set<String> = CORRECT_QUIZ_IDS,
-    incorrectQuizIds: Set<String> = INCORRECT_QUIZ_IDS,
-    markedQuizIds: Set<String> = MARKED_QUIZ_IDS,
+    correctQuizIds: HashSet<String> = CORRECT_QUIZ_IDS,
+    incorrectQuizIds: HashSet<String> = INCORRECT_QUIZ_IDS,
+    markedQuizIds: HashSet<String> = MARKED_QUIZ_IDS,
 ): UserResponse =
     UserResponse(
         id = id,

--- a/src/test/kotlin/com/quizit/quiz/service/ChapterServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/ChapterServiceTest.kt
@@ -8,7 +8,7 @@ import com.quizit.quiz.fixture.createUpdateChapterByIdRequest
 import com.quizit.quiz.repository.ChapterRepository
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldNotBeEqual
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -60,7 +60,7 @@ class ChapterServiceTest : BehaviorSpec() {
 
                 Then("해당 챕터가 수정된다.") {
                     result.expectSubscription()
-                        .assertNext { it shouldNotBeEqualToComparingFields chapterResponse }
+                        .assertNext { it shouldNotBeEqual chapterResponse }
                         .verifyComplete()
                 }
             }

--- a/src/test/kotlin/com/quizit/quiz/service/ChapterServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/ChapterServiceTest.kt
@@ -8,12 +8,13 @@ import com.quizit.quiz.fixture.createUpdateChapterByIdRequest
 import com.quizit.quiz.repository.ChapterRepository
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.equality.shouldBeEqualToComparingFields
-import io.kotest.matchers.equals.shouldNotBeEqual
-import io.mockk.*
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.toList
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
 
 class ChapterServiceTest : BehaviorSpec() {
     private val chapterRepository = mockk<ChapterRepository>()
@@ -23,60 +24,73 @@ class ChapterServiceTest : BehaviorSpec() {
     override fun isolationMode(): IsolationMode = IsolationMode.InstancePerTest
 
     init {
-        Given("코스와 각각의 코스에 속하는 챕터들이 존재하는 경우") {
-            val chapter = createChapter().also {
-                coEvery { chapterRepository.findById(any()) } returns it
-                coEvery { chapterRepository.deleteById(any()) } just runs
-            }
-            val chapters = List(3) { chapter }.apply {
-                asFlow().let {
-                    coEvery { chapterRepository.findAllByCourseId(any()) } returns it
+        Given("챕터들이 존재하는 경우") {
+            val chapter = createChapter()
+                .also {
+                    every { chapterRepository.findAllByCourseId(any()) } returns Flux.just(it)
+                    every { chapterRepository.findById(any<String>()) } returns Mono.just(it)
+                    every { chapterRepository.deleteById(any<String>()) } returns Mono.empty()
                 }
-            }
-            val updateChapterByIdRequest = createUpdateChapterByIdRequest(description = "update").also {
-                coEvery { chapterRepository.save(any()) } returns createChapter(description = it.description)
-            }
+            val chapterResponse = ChapterResponse(chapter)
 
-            When("유저가 코스에 들어가면") {
-                val chapterResponses = chapterService.getChaptersByCourseId(ID).toList()
-                val chapterResponse = chapterService.getChapterById(ID)
+            When("유저가 메인 화면에 들어가면") {
+                val results = listOf(
+                    StepVerifier.create(chapterService.getChaptersByCourseId(ID)),
+                    StepVerifier.create(chapterService.getChapterById(ID))
+                )
 
-                Then("해당 코스에 속하는 챕터들이 주어진다.") {
-                    chapterResponses shouldContainExactly chapters.map { ChapterResponse(it) }
-                    chapterResponse shouldBeEqualToComparingFields ChapterResponse(chapter)
+                Then("챕터가 주어진다.") {
+                    results.map {
+                        it.expectSubscription()
+                            .expectNext(chapterResponse)
+                            .verifyComplete()
+                    }
                 }
             }
 
             When("어드민이 특정 챕터를 수정하면") {
-                val chapterResponse = chapterService.updateChapterById(ID, updateChapterByIdRequest)
+                val updateChapterByIdRequest = createUpdateChapterByIdRequest(description = "updated_description")
+                    .also {
+                        every { chapterRepository.save(any()) } returns Mono.just(
+                            createChapter(description = it.description)
+                        )
+                    }
+                val result =
+                    StepVerifier.create(chapterService.updateChapterById(ID, updateChapterByIdRequest))
 
                 Then("해당 챕터가 수정된다.") {
-                    chapterResponse.description shouldNotBeEqual chapter.description
+                    result.expectSubscription()
+                        .assertNext { it shouldNotBeEqualToComparingFields chapterResponse }
+                        .verifyComplete()
                 }
             }
 
             When("어드민이 특정 챕터를 삭제하면") {
                 chapterService.deleteChapterById(ID)
+                    .subscribe()
 
                 Then("해당 챕터가 삭제된다.") {
-                    coVerify { chapterRepository.deleteById(any()) }
+                    verify { chapterRepository.deleteById(any<String>()) }
                 }
             }
         }
 
         Given("어드민이 챕터를 작성 중인 경우") {
-            val chapter = createChapter().also {
-                coEvery { chapterRepository.save(any()) } returns it
-            }
+            val chapter = createChapter()
+                .also {
+                    every { chapterRepository.save(any()) } returns Mono.just(it)
+                }
+            val chapterResponse = ChapterResponse(chapter)
 
             When("어드민이 챕터를 제출하면") {
-                val chapterResponse = chapterService.createChapter(createCreateChapterRequest())
+                val result = StepVerifier.create(chapterService.createChapter(createCreateChapterRequest()))
 
                 Then("챕터가 생성된다.") {
-                    chapterResponse shouldBeEqualToComparingFields ChapterResponse(chapter)
+                    result.expectSubscription()
+                        .expectNext(chapterResponse)
+                        .verifyComplete()
                 }
             }
         }
-
     }
 }

--- a/src/test/kotlin/com/quizit/quiz/service/CourseServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/CourseServiceTest.kt
@@ -8,7 +8,7 @@ import com.quizit.quiz.fixture.createUpdateCourseByIdRequest
 import com.quizit.quiz.repository.CourseRepository
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldNotBeEqual
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -58,7 +58,7 @@ class CourseServiceTest : BehaviorSpec() {
 
                 Then("해당 코스가 수정된다.") {
                     result.expectSubscription()
-                        .assertNext { it shouldNotBeEqualToComparingFields courseResponse }
+                        .assertNext { it shouldNotBeEqual courseResponse }
                         .verifyComplete()
                 }
             }

--- a/src/test/kotlin/com/quizit/quiz/service/CurriculumServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/CurriculumServiceTest.kt
@@ -8,7 +8,7 @@ import com.quizit.quiz.fixture.createUpdateCurriculumByIdRequest
 import com.quizit.quiz.repository.CurriculumRepository
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+import io.kotest.matchers.equals.shouldNotBeEqual
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -58,7 +58,7 @@ class CurriculumServiceTest : BehaviorSpec() {
 
                 Then("해당 커리큘럼이 수정된다.") {
                     result.expectSubscription()
-                        .assertNext { it shouldNotBeEqualToComparingFields curriculumResponse }
+                        .assertNext { it shouldNotBeEqual curriculumResponse }
                         .verifyComplete()
                 }
             }

--- a/src/test/kotlin/com/quizit/quiz/service/CurriculumServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/CurriculumServiceTest.kt
@@ -8,12 +8,13 @@ import com.quizit.quiz.fixture.createUpdateCurriculumByIdRequest
 import com.quizit.quiz.repository.CurriculumRepository
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.equality.shouldBeEqualToComparingFields
-import io.kotest.matchers.equals.shouldNotBeEqual
-import io.mockk.*
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.toList
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
 
 class CurriculumServiceTest : BehaviorSpec() {
     private val curriculumRepository = mockk<CurriculumRepository>()
@@ -24,56 +25,68 @@ class CurriculumServiceTest : BehaviorSpec() {
 
     init {
         Given("커리큘럼들이 존재하는 경우") {
-            val curriculum = createCurriculum().also {
-                coEvery { curriculumRepository.findById(any()) } returns it
-                coEvery { curriculumRepository.deleteById(any()) } just runs
-            }
-            val curriculums = List(3) { curriculum }.apply {
-                asFlow().let {
-                    coEvery { curriculumRepository.findAll() } returns it
+            val curriculum = createCurriculum()
+                .also {
+                    every { curriculumRepository.findAll() } returns Flux.just(it)
+                    every { curriculumRepository.findById(any<String>()) } returns Mono.just(it)
+                    every { curriculumRepository.deleteById(any<String>()) } returns Mono.empty()
                 }
-            }
-            val updateCurriculumByIdRequest = createUpdateCurriculumByIdRequest(title = "update").also {
-                coEvery { curriculumRepository.save(any()) } returns createCurriculum(title = it.title)
-            }
+            val curriculumResponse = CurriculumResponse(curriculum)
 
             When("유저가 메인 화면에 들어가면") {
-                val curriculumResponses = curriculumService.getCurriculums().toList()
-                val curriculumResponse = curriculumService.getCurriculumById(ID)
+                val results = listOf(
+                    StepVerifier.create(curriculumService.getCurriculums()),
+                    StepVerifier.create(curriculumService.getCurriculumById(ID))
+                )
 
                 Then("커리큘럼이 주어진다.") {
-                    curriculumResponses shouldContainExactly curriculums.map { CurriculumResponse(it) }
-                    curriculumResponse shouldBeEqualToComparingFields CurriculumResponse(curriculum)
+                    results.map {
+                        it.expectSubscription()
+                            .expectNext(curriculumResponse)
+                            .verifyComplete()
+                    }
                 }
             }
 
             When("어드민이 특정 커리큘럼을 수정하면") {
-                val chapterResponse = curriculumService.updateCurriculumById(ID, updateCurriculumByIdRequest)
+                val updateCurriculumByIdRequest = createUpdateCurriculumByIdRequest(title = "updated_title")
+                    .also {
+                        every { curriculumRepository.save(any()) } returns Mono.just(createCurriculum(title = it.title))
+                    }
+                val result =
+                    StepVerifier.create(curriculumService.updateCurriculumById(ID, updateCurriculumByIdRequest))
 
                 Then("해당 커리큘럼이 수정된다.") {
-                    chapterResponse.title shouldNotBeEqual curriculum.title
+                    result.expectSubscription()
+                        .assertNext { it shouldNotBeEqualToComparingFields curriculumResponse }
+                        .verifyComplete()
                 }
             }
 
             When("어드민이 특정 커리큘럼을 삭제하면") {
                 curriculumService.deleteCurriculumById(ID)
+                    .subscribe()
 
                 Then("해당 커리큘럼이 삭제된다.") {
-                    coVerify { curriculumRepository.deleteById(any()) }
+                    verify { curriculumRepository.deleteById(any<String>()) }
                 }
             }
         }
 
         Given("어드민이 커리큘럼을 작성 중인 경우") {
-            val curriculum = createCurriculum().also {
-                coEvery { curriculumRepository.save(any()) } returns it
-            }
+            val curriculum = createCurriculum()
+                .also {
+                    every { curriculumRepository.save(any()) } returns Mono.just(it)
+                }
+            val curriculumResponse = CurriculumResponse(curriculum)
 
             When("어드민이 커리큘럼을 제출하면") {
-                val curriculumResponse = curriculumService.createCurriculum(createCreateCurriculumRequest())
+                val result = StepVerifier.create(curriculumService.createCurriculum(createCreateCurriculumRequest()))
 
                 Then("커리큘럼이 생성된다.") {
-                    curriculumResponse shouldBeEqualToComparingFields CurriculumResponse(curriculum)
+                    result.expectSubscription()
+                        .expectNext(curriculumResponse)
+                        .verifyComplete()
                 }
             }
         }

--- a/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
@@ -8,28 +8,34 @@ import com.quizit.quiz.repository.QuizCacheRepository
 import com.quizit.quiz.repository.QuizRepository
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.collections.shouldContainExactly
-import io.kotest.matchers.equality.shouldBeEqualToComparingFields
-import io.kotest.matchers.equals.shouldNotBeEqual
+import io.kotest.matchers.equality.shouldNotBeEqualToComparingFields
 import io.kotest.matchers.ints.shouldBeGreaterThan
 import io.kotest.matchers.ints.shouldBeLessThan
-import io.mockk.*
-import kotlinx.coroutines.flow.asFlow
-import kotlinx.coroutines.flow.toList
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import reactor.core.publisher.Flux
+import reactor.core.publisher.Mono
+import reactor.test.StepVerifier
 
 class QuizServiceTest : BehaviorSpec() {
     private val quizRepository = mockk<QuizRepository>()
 
-    private val quizCacheRepository = mockk<QuizCacheRepository>().apply {
-        coEvery { save(any()) } returns true
-    }
+    private val quizCacheRepository = mockk<QuizCacheRepository>()
+        .apply {
+            every { save(any()) } returns Mono.just(true)
+        }
 
     private val userClient = mockk<UserClient>()
+        .apply {
+            every { getUserById(any()) } returns Mono.just(createUserResponse())
+        }
 
-    private val quizProducer = mockk<QuizProducer>().apply {
-        coEvery { checkAnswer(any()) } just runs
-        coEvery { markQuiz(any()) } just runs
-    }
+    private val quizProducer = mockk<QuizProducer>()
+        .apply {
+            every { checkAnswer(any()) } returns Mono.empty()
+            every { markQuiz(any()) } returns Mono.empty()
+        }
 
     private val quizService = QuizService(
         quizRepository = quizRepository,
@@ -42,114 +48,124 @@ class QuizServiceTest : BehaviorSpec() {
 
     init {
         Given("챕터와 각각의 챕터에 속하는 퀴즈들이 존재하는 경우") {
-            val quiz = createQuiz().also {
-                coEvery { quizRepository.deleteById(any()) } just runs
-                coEvery { quizCacheRepository.findById(any()) } returns it
-                coEvery { quizCacheRepository.deleteById(any()) } returns true
-            }
-            val quizzes = listOf(quiz).apply {
-                asFlow().let {
-                    coEvery {
+            val quiz = createQuiz()
+                .also {
+                    every { quizRepository.findAllByIdIn(any()) } returns Flux.just(it)
+                    every { quizRepository.findAllByQuestionContains(any()) } returns Flux.just(it)
+                    every {
                         quizRepository.findAllByChapterIdAndAnswerRateBetween(any(), any(), any(), any())
-                    } returns it
-                    coEvery { quizRepository.findAllByIdIn(any()) } returns it
-                    coEvery { quizRepository.findAllByQuestionContains(any()) } returns it
+                    } returns Flux.just(it)
+                    every { quizRepository.deleteById(any<String>()) } returns Mono.empty()
+                    every { quizCacheRepository.deleteById(any()) } returns Mono.empty()
+                    every { quizCacheRepository.findById(any<String>()) } returns Mono.just(it)
                 }
-            }
-            val updateQuizByIdRequest = createUpdateQuizByIdRequest(question = "update").apply {
-                createQuiz(question = question).let {
-                    coEvery { quizRepository.save(any()) } returns it
-                }
-            }
+            val quizResponse = QuizResponse(quiz)
 
             When("유저가 특정 퀴즈를 조회하면") {
-                val quizResponse = quizService.getQuizById(ID)
+                val result = StepVerifier.create(quizService.getQuizById(ID))
 
                 Then("해당 퀴즈가 조회된다.") {
-                    quizResponse shouldBeEqualToComparingFields QuizResponse(quiz)
+                    result.expectSubscription()
+                        .expectNext(quizResponse)
+                        .verifyComplete()
                 }
             }
 
             When("유저가 특정 퀴즈를 문제 지문을 통해 검색하면") {
-                val quizResponses = quizService.getQuizzesByQuestionContains(QUESTION).toList()
+                val result = StepVerifier.create(quizService.getQuizzesByQuestionContains(QUESTION))
 
                 Then("해당 키워드가 들어간 문제 지문을 가진 퀴즈가 조회된다.") {
-                    quizResponses shouldContainExactly quizzes.map { QuizResponse(it) }
+                    result.expectSubscription()
+                        .expectNext(quizResponse)
+                        .verifyComplete()
                 }
             }
 
             When("유저가 챕터를 들어가면") {
-                val quizResponses =
-                    quizService.getQuizzesByChapterIdAndAnswerRateRange(ID, setOf(0.0, 100.0), PAGEABLE).toList()
+                val result =
+                    StepVerifier.create(
+                        quizService.getQuizzesByChapterIdAndAnswerRateRange(ID, setOf(0.0, 100.0), PAGEABLE)
+                    )
 
                 Then("해당 챕터에 속하는 퀴즈들이 주어진다.") {
-                    quizzes.map { QuizResponse(it) }.let {
-                        quizResponses shouldContainExactly it
-                    }
+                    result.expectSubscription()
+                        .expectNext(quizResponse)
+                        .verifyComplete()
                 }
             }
 
             When("유저가 특정 퀴즈를 수정하면") {
-                val quizResponse = quizService.updateQuizById(ID, createJwtAuthentication(), updateQuizByIdRequest)
+                val updateQuizByIdRequest = createUpdateQuizByIdRequest(question = "updated_question")
+                    .also {
+                        every { quizRepository.save(any()) } returns Mono.just(createQuiz(question = it.question))
+                    }
+                val result = StepVerifier.create(
+                    quizService.updateQuizById(ID, createJwtAuthentication(), updateQuizByIdRequest)
+                )
 
                 Then("해당 퀴즈가 수정된다.") {
-                    quizResponse.question shouldNotBeEqual quiz.question
+                    result.expectSubscription()
+                        .assertNext { it shouldNotBeEqualToComparingFields quizResponse }
+                        .verifyComplete()
                 }
             }
 
             When("유저가 특정 퀴즈를 삭제하면") {
                 quizService.deleteQuizById(ID, createJwtAuthentication())
+                    .subscribe()
 
                 Then("해당 퀴즈가 삭제된다.") {
-                    coVerify { quizRepository.deleteById(any()) }
+                    verify { quizRepository.deleteById(any<String>()) }
                 }
             }
         }
 
         Given("유저가 저장한 퀴즈가 존재하는 경우") {
-            val quizzes = listOf(createQuiz()).apply {
-                asFlow().let {
-                    coEvery { quizRepository.findAllByIdIn(any()) } returns it
+            val quiz = createQuiz()
+                .also {
+                    every { quizRepository.findAllByIdIn(any()) } returns Flux.just(it)
                 }
-            }
-
-            coEvery { userClient.getUserById(any()) } returns createUserResponse()
+            val quizResponse = QuizResponse(quiz)
 
             When("유저가 본인이 저장한 퀴즈 보관함에 들어가면") {
-                val quizResponses = quizService.getMarkedQuizzes(ID).toList()
+                val result = StepVerifier.create(quizService.getMarkedQuizzes(ID))
 
                 Then("유저가 저장한 퀴즈들이 주어진다.") {
-                    quizResponses shouldContainExactly quizzes.map { QuizResponse(it) }
+                    result.expectSubscription()
+                        .expectNext(quizResponse)
+                        .verifyComplete()
                 }
             }
         }
 
         Given("유저가 작성한 퀴즈가 존재하는 경우") {
-            val quizzes = listOf(createQuiz()).apply {
-                asFlow().let {
-                    coEvery { quizRepository.findAllByWriterId(any()) } returns it
+            val quiz = createQuiz()
+                .also {
+                    every { quizRepository.findAllByWriterId(any()) } returns Flux.just(it)
                 }
-            }
+            val quizResponse = QuizResponse(quiz)
 
             When("유저가 본인이 작성한 퀴즈 보관함에 들어가면") {
-                val quizResponses = quizService.getQuizzesByWriterId(ID).toList()
+                val result = StepVerifier.create(quizService.getQuizzesByWriterId(ID))
 
                 Then("본인이 작성한 퀴즈들이 주어진다.") {
-                    quizResponses shouldContainExactly quizzes.map { QuizResponse(it) }
+                    result.expectSubscription()
+                        .expectNext(quizResponse)
+                        .verifyComplete()
                 }
             }
         }
 
         Given("유저가 퀴즈를 푼 경우") {
-            createQuiz().also {
-                coEvery { quizRepository.save(any()) } returns it
-                coEvery { quizCacheRepository.findById(any()) } returns it
-            }
-
-            coEvery { userClient.getUserById(any()) } returns createUserResponse()
+            createQuiz()
+                .also {
+                    every { quizRepository.save(any()) } returns Mono.just(it)
+                    every { quizCacheRepository.findById(any()) } returns Mono.just(it)
+                }
 
             When("옳은 답을 제출하면") {
                 quizService.checkAnswer(ID, ID, createCheckAnswerRequest())
+                    .subscribe()
 
                 Then("정답으로 처리되어 정답률이 변경된다.") {
                     verify { quizProducer.checkAnswer(any()) }
@@ -158,6 +174,7 @@ class QuizServiceTest : BehaviorSpec() {
 
             When("틀린 답을 제출하면") {
                 quizService.checkAnswer(ID, ID, createCheckAnswerRequest(answer = -1))
+                    .subscribe()
 
                 Then("오답으로 처리되어 정답률이 변경된다.") {
                     verify { quizProducer.checkAnswer(any()) }
@@ -166,15 +183,15 @@ class QuizServiceTest : BehaviorSpec() {
         }
 
         Given("유저가 이미 푼 퀴즈가 존재하는 경우") {
-            val quiz = createQuiz(id = "quiz").also {
-                coEvery { quizRepository.save(any()) } returns it
-                coEvery { quizCacheRepository.findById(any()) } returns it
-            }
-
-            coEvery { userClient.getUserById(any()) } returns createUserResponse()
+            createQuiz(id = "quiz")
+                .also {
+                    every { quizRepository.save(any()) } returns Mono.just(it)
+                    every { quizCacheRepository.findById(any()) } returns Mono.just(it)
+                }
 
             When("해당 퀴즈를 풀고 정답을 제출하면") {
-                quizService.checkAnswer(quiz.id!!, ID, createCheckAnswerRequest())
+                quizService.checkAnswer(CORRECT_QUIZ_IDS.random(), ID, createCheckAnswerRequest())
+                    .subscribe()
 
                 Then("채점만 되고 정답률은 변경되지 않는다.") {
                     verify(exactly = 0) { quizProducer.checkAnswer(any()) }
@@ -182,7 +199,8 @@ class QuizServiceTest : BehaviorSpec() {
             }
 
             When("해당 퀴즈를 풀고 오답을 제출하면") {
-                quizService.checkAnswer(quiz.id!!, ID, createCheckAnswerRequest(answer = -1))
+                quizService.checkAnswer(CORRECT_QUIZ_IDS.random(), ID, createCheckAnswerRequest(answer = -1))
+                    .subscribe()
 
                 Then("채점만 되고 정답률은 변경되지 않는다.") {
                     verify(exactly = 0) { quizProducer.checkAnswer(any()) }
@@ -191,84 +209,103 @@ class QuizServiceTest : BehaviorSpec() {
         }
 
         Given("유저가 퀴즈를 작성하는 중인 경우") {
-            val quiz = createQuiz().also {
-                coEvery { quizRepository.save(any()) } returns it
-            }
+            val quiz = createQuiz()
+                .also {
+                    every { quizRepository.save(any()) } returns Mono.just(it)
+                }
+            val quizResponse = QuizResponse(quiz)
 
             When("유저가 퀴즈를 제출하면") {
-                val quizResponse = quizService.createQuiz(ID, createCreateQuizRequest())
+                val result = StepVerifier.create(quizService.createQuiz(ID, createCreateQuizRequest()))
 
                 Then("퀴즈가 생성된다.") {
-                    quizResponse shouldBeEqualToComparingFields QuizResponse(quiz)
+                    result.expectSubscription()
+                        .expectNext(quizResponse)
+                        .verifyComplete()
                 }
             }
         }
 
         Given("유저가 퀴즈를 저장하는 경우") {
-            val quiz = createQuiz().also {
-                coEvery { quizRepository.save(any()) } returns it
-                coEvery { quizCacheRepository.findById(any()) } returns it
-            }
+            val quiz = createQuiz()
+                .also {
+                    every { quizRepository.save(any()) } returns Mono.just(it)
+                    every { quizCacheRepository.findById(any()) } returns Mono.just(it)
+                }
 
             When("유저가 해당 퀴즈를 처음 저장한다면") {
                 quizService.markQuiz(ID, ID)
+                    .subscribe()
 
                 Then("퀴즈가 저장된다.") {
                     quiz.markedUserIds.size shouldBeGreaterThan createQuiz().markedUserIds.size
+                    verify { quizRepository.save(any()) }
                 }
             }
 
             When("이미 유저가 해당 퀴즈를 저장한 상태라면") {
                 quizService.markQuiz(ID, quiz.markedUserIds.random())
+                    .subscribe()
 
                 Then("퀴즈가 저장 취소된다.") {
                     quiz.markedUserIds.size shouldBeLessThan createQuiz().markedUserIds.size
+                    verify { quizRepository.save(any()) }
                 }
             }
         }
 
         Given("유저가 퀴즈를 좋아요로 평가하는 경우") {
-            val quiz = createQuiz().also {
-                coEvery { quizRepository.save(any()) } returns it
-                coEvery { quizCacheRepository.findById(any()) } returns it
-            }
+            val quiz = createQuiz()
+                .also {
+                    every { quizRepository.save(any()) } returns Mono.just(it)
+                    every { quizCacheRepository.findById(any()) } returns Mono.just(it)
+                }
 
             When("유저가 해당 퀴즈를 처음 좋아요로 평가한다면") {
                 quizService.evaluateQuiz(ID, ID, true)
+                    .subscribe()
 
                 Then("퀴즈가 평가된다.") {
                     quiz.likedUserIds.size shouldBeGreaterThan createQuiz().likedUserIds.size
+                    verify { quizRepository.save(any()) }
                 }
             }
 
             When("유저가 이미 해당 퀴즈를 좋아요로 평가한 상태라면") {
                 quizService.evaluateQuiz(ID, quiz.likedUserIds.random(), true)
+                    .subscribe()
 
                 Then("퀴즈 평가가 취소된다.") {
                     quiz.likedUserIds.size shouldBeLessThan createQuiz().likedUserIds.size
+                    verify { quizRepository.save(any()) }
                 }
             }
         }
 
         Given("유저가 퀴즈를 싫어요로 평가하는 경우") {
-            val quiz = createQuiz().also {
-                coEvery { quizRepository.save(any()) } returns it
-                coEvery { quizCacheRepository.findById(any()) } returns it
-            }
+            val quiz = createQuiz()
+                .also {
+                    every { quizRepository.save(any()) } returns Mono.just(it)
+                    every { quizCacheRepository.findById(any()) } returns Mono.just(it)
+                }
 
             When("유저가 해당 퀴즈를 처음 싫어요로 평가한다면") {
                 quizService.evaluateQuiz(ID, ID, false)
+                    .subscribe()
 
                 Then("퀴즈가 평가된다.") {
                     quiz.unlikedUserIds.size shouldBeGreaterThan createQuiz().unlikedUserIds.size
+                    verify { quizRepository.save(any()) }
                 }
             }
 
             When("유저가 이미 해당 퀴즈를 좋아요로 평가한 상태라면") {
                 quizService.evaluateQuiz(ID, quiz.unlikedUserIds.random(), false)
+                    .subscribe()
 
                 Then("퀴즈 평가가 취소된다.") {
                     quiz.unlikedUserIds.size shouldBeLessThan createQuiz().unlikedUserIds.size
+                    verify { quizRepository.save(any()) }
                 }
             }
         }

--- a/src/test/kotlin/com/quizit/quiz/util/TestUtil.kt
+++ b/src/test/kotlin/com/quizit/quiz/util/TestUtil.kt
@@ -9,10 +9,12 @@ import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
 
 infix fun String.desc(description: String): FieldDescriptor =
-    fieldWithPath(this).description(description)
+    fieldWithPath(this)
+        .description(description)
 
 infix fun String.paramDesc(description: String): ParameterDescriptor =
-    parameterWithName(this).description(description)
+    parameterWithName(this)
+        .description(description)
 
 fun withMockUser() {
     SecurityContextHolder.getContext().authentication = createJwtAuthentication()

--- a/src/test/kotlin/com/quizit/quiz/util/TestUtil.kt
+++ b/src/test/kotlin/com/quizit/quiz/util/TestUtil.kt
@@ -1,5 +1,6 @@
 package com.quizit.quiz.util
 
+import com.quizit.quiz.domain.enum.Role
 import com.quizit.quiz.fixture.createJwtAuthentication
 import org.springframework.restdocs.payload.FieldDescriptor
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
@@ -22,7 +23,7 @@ fun withMockUser() {
 
 fun withMockAdmin() {
     SecurityContextHolder.getContext().authentication =
-        createJwtAuthentication(authorities = listOf(SimpleGrantedAuthority("ADMIN")))
+        createJwtAuthentication(authorities = listOf(SimpleGrantedAuthority(Role.ADMIN.name)))
 }
 
 val errorResponseFields = listOf(


### PR DESCRIPTION
## 작업 내용

* **Spring WebFlux 환경에서 사용하던 Coroutine을 Reactive Streams 구현체인 Reactor로 대체**

## 코멘트

* 향후 추가될 Spring Reactive Stack 관련 기능들(OAuth, DynamoDB 등)에 대한 호환성 및 확장성을 위해 수행된 작업

## 관련 이슈

* **Close #60**