### PR TITLE
[#62] 좋아요한 유저 및 저장한 유저 식별자 리스트 필드 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/quizit/quiz/dto/response/CurriculumResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/CurriculumResponse.kt
@@ -8,7 +8,7 @@ data class CurriculumResponse(
     val image: String,
 ) {
     companion object {
-        operator fun invoke(curriculum: Curriculum) =
+        operator fun invoke(curriculum: Curriculum): CurriculumResponse =
             with(curriculum) {
                 CurriculumResponse(
                     id = id!!,

--- a/src/main/kotlin/com/quizit/quiz/dto/response/LikedUserIdsResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/LikedUserIdsResponse.kt
@@ -1,0 +1,18 @@
+package com.quizit.quiz.dto.response
+
+import com.quizit.quiz.domain.Quiz
+
+data class LikedUserIdsResponse(
+    val likedUserIds: HashSet<String>,
+    val unlikedUserIds: HashSet<String>
+) {
+    companion object {
+        operator fun invoke(quiz: Quiz): LikedUserIdsResponse =
+            with(quiz) {
+                LikedUserIdsResponse(
+                    likedUserIds = likedUserIds,
+                    unlikedUserIds = unlikedUserIds
+                )
+            }
+    }
+}

--- a/src/main/kotlin/com/quizit/quiz/dto/response/MarkedUserIdsResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/MarkedUserIdsResponse.kt
@@ -1,0 +1,12 @@
+package com.quizit.quiz.dto.response
+
+import com.quizit.quiz.domain.Quiz
+
+data class MarkedUserIdsResponse(
+    val markedUserIds: HashSet<String>
+) {
+    companion object {
+        operator fun invoke(quiz: Quiz): MarkedUserIdsResponse =
+            MarkedUserIdsResponse(markedUserIds = quiz.markedUserIds)
+    }
+}

--- a/src/main/kotlin/com/quizit/quiz/dto/response/QuizResponse.kt
+++ b/src/main/kotlin/com/quizit/quiz/dto/response/QuizResponse.kt
@@ -18,7 +18,7 @@ data class QuizResponse(
     val createdDate: LocalDateTime,
 ) {
     companion object {
-        operator fun invoke(quiz: Quiz) =
+        operator fun invoke(quiz: Quiz): QuizResponse =
             with(quiz) {
                 QuizResponse(
                     id = id!!,

--- a/src/main/kotlin/com/quizit/quiz/handler/QuizHandler.kt
+++ b/src/main/kotlin/com/quizit/quiz/handler/QuizHandler.kt
@@ -54,6 +54,14 @@ class QuizHandler(
         ServerResponse.ok()
             .body(quizService.getMarkedQuizzes(request.pathVariable("id")))
 
+    fun getMarkedUserIdsById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(quizService.getMarkedUserIdsById(request.pathVariable("id")))
+
+    fun getLikedUserIdsById(request: ServerRequest): Mono<ServerResponse> =
+        ServerResponse.ok()
+            .body(quizService.getLikedUserIdsById(request.pathVariable("id")))
+
     fun createQuiz(request: ServerRequest): Mono<ServerResponse> =
         with(request) {
             Mono.zip(authentication(), bodyToMono<CreateQuizRequest>())

--- a/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
+++ b/src/main/kotlin/com/quizit/quiz/router/QuizRouter.kt
@@ -16,6 +16,8 @@ class QuizRouter {
             "/quiz".nest {
                 GET("/search", queryParams("question"), handler::getQuizzesByQuestionContains)
                 GET("/{id}", handler::getQuizById)
+                GET("/{id}/marked-user-ids", handler::getMarkedUserIdsById)
+                GET("/{id}/liked-user-ids", handler::getLikedUserIdsById)
                 GET(
                     "/chapter/{id}",
                     queryParams("page", "size", "range"),

--- a/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
+++ b/src/main/kotlin/com/quizit/quiz/service/QuizService.kt
@@ -10,6 +10,8 @@ import com.quizit.quiz.dto.request.CheckAnswerRequest
 import com.quizit.quiz.dto.request.CreateQuizRequest
 import com.quizit.quiz.dto.request.UpdateQuizByIdRequest
 import com.quizit.quiz.dto.response.CheckAnswerResponse
+import com.quizit.quiz.dto.response.LikedUserIdsResponse
+import com.quizit.quiz.dto.response.MarkedUserIdsResponse
 import com.quizit.quiz.dto.response.QuizResponse
 import com.quizit.quiz.exception.PermissionDeniedException
 import com.quizit.quiz.exception.QuizNotFoundException
@@ -56,6 +58,16 @@ class QuizService(
         userClient.getUserById(userId)
             .flatMapMany { quizRepository.findAllByIdIn(it.markedQuizIds.toList()) }
             .map { QuizResponse(it) }
+
+    fun getMarkedUserIdsById(id: String): Mono<MarkedUserIdsResponse> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .map { MarkedUserIdsResponse(it) }
+
+    fun getLikedUserIdsById(id: String): Mono<LikedUserIdsResponse> =
+        quizCacheRepository.findById(id)
+            .switchIfEmpty(Mono.error(QuizNotFoundException()))
+            .map { LikedUserIdsResponse(it) }
 
     fun createQuiz(userId: String, request: CreateQuizRequest): Mono<QuizResponse> =
         with(request) {

--- a/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/controller/QuizControllerTest.kt
@@ -3,6 +3,8 @@ package com.quizit.quiz.controller
 import com.epages.restdocs.apispec.WebTestClientRestDocumentationWrapper
 import com.ninjasquad.springmockk.MockkBean
 import com.quizit.quiz.dto.response.CheckAnswerResponse
+import com.quizit.quiz.dto.response.LikedUserIdsResponse
+import com.quizit.quiz.dto.response.MarkedUserIdsResponse
 import com.quizit.quiz.dto.response.QuizResponse
 import com.quizit.quiz.exception.PermissionDeniedException
 import com.quizit.quiz.exception.QuizNotFoundException
@@ -63,6 +65,15 @@ class QuizControllerTest : BaseControllerTest() {
     )
 
     private val quizResponsesFields = quizResponseFields.map { "[].${it.path}" desc it.description as String }
+
+    private val markedUserIdsResponseFields = listOf(
+        "markedUserIds" desc "저장한 유저 리스트"
+    )
+
+    private val likedUserIdsResponseFields = listOf(
+        "likedUserIds" desc "좋아요한 유저 리스트",
+        "unlikedUserIds" desc "싫어요한 유저 리스트"
+    )
 
     private val checkAnswerResponseFields = listOf(
         "answer" desc "정답",
@@ -224,6 +235,102 @@ class QuizControllerTest : BaseControllerTest() {
                                 Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
                                 Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
                                 responseFields(quizResponsesFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("getMarkedUserIdsById()는") {
+            context("유저가 저장한 퀴즈가 존재하는 경우") {
+                every { quizService.getMarkedUserIdsById(any()) } returns Mono.just(createMarkedUserIdsResponse())
+                withMockUser()
+
+                it("상태 코드 200과 markedUserIdsResponse를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/quiz/{id}/marked-user-ids", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(MarkedUserIdsResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "퀴즈를 저장한 유저 식별자 리스트 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                responseFields(markedUserIdsResponseFields)
+                            )
+                        )
+                }
+            }
+
+            context("유저가 저장한 퀴즈가 존재하지 않는 경우") {
+                every { quizService.getMarkedUserIdsById(any()) } throws QuizNotFoundException()
+                withMockUser()
+
+                it("상태 코드 404를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/quiz/{id}/marked-user-ids", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isNotFound
+                        .expectBody(ErrorResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "퀴즈를 저장한 유저 식별자 리스트 조회 실패(404)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                responseFields(errorResponseFields)
+                            )
+                        )
+                }
+            }
+        }
+
+        describe("getLikedUserIdsById()는") {
+            context("유저가 평가한 퀴즈가 존재하는 경우") {
+                every { quizService.getLikedUserIdsById(any()) } returns Mono.just(createLikedUserIdsResponse())
+                withMockUser()
+
+                it("상태 코드 200과 likedUserIdsResponse를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/quiz/{id}/liked-user-ids", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isOk
+                        .expectBody(LikedUserIdsResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "퀴즈를 평가한 유저 식별자 리스트 조회 성공(200)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                responseFields(likedUserIdsResponseFields)
+                            )
+                        )
+                }
+            }
+
+            context("유저가 평가한 퀴즈가 존재하지 않는 경우") {
+                every { quizService.getLikedUserIdsById(any()) } throws QuizNotFoundException()
+                withMockUser()
+
+                it("상태 코드 404를 반환한다.") {
+                    webClient
+                        .get()
+                        .uri("/quiz/{id}/liked-user-ids", ID)
+                        .exchange()
+                        .expectStatus()
+                        .isNotFound
+                        .expectBody(ErrorResponse::class.java)
+                        .consumeWith(
+                            WebTestClientRestDocumentationWrapper.document(
+                                "퀴즈를 평가한 유저 식별자 리스트 조회 실패(404)",
+                                Preprocessors.preprocessRequest(Preprocessors.prettyPrint()),
+                                Preprocessors.preprocessResponse(Preprocessors.prettyPrint()),
+                                responseFields(errorResponseFields)
                             )
                         )
                 }

--- a/src/test/kotlin/com/quizit/quiz/fixture/QuizFixture.kt
+++ b/src/test/kotlin/com/quizit/quiz/fixture/QuizFixture.kt
@@ -5,6 +5,8 @@ import com.quizit.quiz.dto.request.CheckAnswerRequest
 import com.quizit.quiz.dto.request.CreateQuizRequest
 import com.quizit.quiz.dto.request.UpdateQuizByIdRequest
 import com.quizit.quiz.dto.response.CheckAnswerResponse
+import com.quizit.quiz.dto.response.LikedUserIdsResponse
+import com.quizit.quiz.dto.response.MarkedUserIdsResponse
 import com.quizit.quiz.dto.response.QuizResponse
 import java.time.LocalDateTime
 
@@ -90,6 +92,20 @@ fun createQuizResponse(
         likedUserIds = likedUserIds,
         unlikedUserIds = unlikedUserIds,
         createdDate = createdDate
+    )
+
+fun createMarkedUserIdsResponse(
+    markedUserIds: HashSet<String> = MARKED_USER_IDS
+): MarkedUserIdsResponse =
+    MarkedUserIdsResponse(markedUserIds = markedUserIds)
+
+fun createLikedUserIdsResponse(
+    likedUserIds: HashSet<String> = LIKED_USER_IDS,
+    unlikedUserIds: HashSet<String> = UNLIKED_USER_IDS
+): LikedUserIdsResponse =
+    LikedUserIdsResponse(
+        likedUserIds = likedUserIds,
+        unlikedUserIds = unlikedUserIds
     )
 
 fun createQuiz(

--- a/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
+++ b/src/test/kotlin/com/quizit/quiz/service/QuizServiceTest.kt
@@ -2,6 +2,8 @@ package com.quizit.quiz.service
 
 import com.quizit.quiz.adapter.client.UserClient
 import com.quizit.quiz.adapter.producer.QuizProducer
+import com.quizit.quiz.dto.response.LikedUserIdsResponse
+import com.quizit.quiz.dto.response.MarkedUserIdsResponse
 import com.quizit.quiz.dto.response.QuizResponse
 import com.quizit.quiz.fixture.*
 import com.quizit.quiz.repository.QuizCacheRepository
@@ -60,6 +62,8 @@ class QuizServiceTest : BehaviorSpec() {
                     every { quizCacheRepository.findById(any<String>()) } returns Mono.just(it)
                 }
             val quizResponse = QuizResponse(quiz)
+            val markedUserIdsResponse = MarkedUserIdsResponse(quiz)
+            val likedUserIdsResponse = LikedUserIdsResponse(quiz)
 
             When("유저가 특정 퀴즈를 조회하면") {
                 val result = StepVerifier.create(quizService.getQuizById(ID))
@@ -90,6 +94,26 @@ class QuizServiceTest : BehaviorSpec() {
                 Then("해당 챕터에 속하는 퀴즈들이 주어진다.") {
                     result.expectSubscription()
                         .expectNext(quizResponse)
+                        .verifyComplete()
+                }
+            }
+
+            When("유저가 퀴즈를 저장한 유저들을 조회하는 경우") {
+                val result = StepVerifier.create(quizService.getMarkedUserIdsById(ID))
+
+                Then("해당 퀴즈를 저장한 유저 식별자 리스트가 주어진다.") {
+                    result.expectSubscription()
+                        .expectNext(markedUserIdsResponse)
+                        .verifyComplete()
+                }
+            }
+
+            When("유저가 퀴즈를 평가한 유저들을 조회하는 경우") {
+                val result = StepVerifier.create(quizService.getLikedUserIdsById(ID))
+
+                Then("해당 퀴즈를 평가한 유저 식별자 리스트가 주어진다.") {
+                    result.expectSubscription()
+                        .expectNext(likedUserIdsResponse)
                         .verifyComplete()
                 }
             }


### PR DESCRIPTION
## 작업 내용

* **좋아요한 유저 및 저장한 유저 식별자 리스트 조회 기능 구현**

## 관련 이슈

* **Close #62**